### PR TITLE
Add decoder block

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,4 @@ dRAGon/
 
 * Implemented a naive self-attention layer in Rust (`core/src/attention.rs`) as the first step toward the full decoder.
 * Added a simple two-layer feedforward network (`core/src/feedforward.rs`).
+* Created a minimal decoder block chaining attention and feedforward (`core/src/decoder.rs`).

--- a/core/src/decoder.rs
+++ b/core/src/decoder.rs
@@ -1,0 +1,41 @@
+use crate::attention::SelfAttention;
+use crate::feedforward::FeedForward;
+
+/// Simplified decoder block combining self-attention and feedforward layers.
+///
+/// This block applies self-attention followed by a feedforward network. Both
+/// components use identity weights so the block can be unit tested easily.
+pub struct DecoderBlock {
+    pub self_attn: SelfAttention,
+    pub feedforward: FeedForward,
+}
+
+impl DecoderBlock {
+    /// Creates a new [`DecoderBlock`].
+    pub fn new(embed_dim: usize, hidden_dim: usize) -> Self {
+        Self {
+            self_attn: SelfAttention::new(embed_dim),
+            feedforward: FeedForward::new(embed_dim, hidden_dim),
+        }
+    }
+
+    /// Runs the block on the provided sequence.
+    pub fn forward(&self, input: &[Vec<f32>]) -> Vec<Vec<f32>> {
+        let attn_out = self.self_attn.forward(input);
+        self.feedforward.forward(&attn_out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decoder_block_forward_shape() {
+        let block = DecoderBlock::new(2, 2);
+        let input = vec![vec![0.5f32, -0.5]];
+        let output = block.forward(&input);
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].len(), 2);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod attention;
 pub mod feedforward;
+pub mod decoder;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right


### PR DESCRIPTION
## Summary
- add new decoder block in Rust combining self-attention and feedforward
- expose module in library
- document decoder block in project README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c2b722c488322a125189a59b45983