### PR TITLE
Implement simple Transformer struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ dRAGon/
 * Implemented a naive self-attention layer in Rust (`core/src/attention.rs`) as the first step toward the full decoder.
 * Added a simple two-layer feedforward network (`core/src/feedforward.rs`).
 * Created a minimal decoder block chaining attention and feedforward (`core/src/decoder.rs`).
+* Introduced a simple multi-layer `Transformer` composed of decoder blocks (`core/src/transformer.rs`).

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod attention;
 pub mod feedforward;
 pub mod decoder;
+pub mod transformer;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/core/src/transformer.rs
+++ b/core/src/transformer.rs
@@ -1,0 +1,36 @@
+use crate::decoder::DecoderBlock;
+
+/// Simple Transformer consisting of repeated [`DecoderBlock`]s.
+pub struct Transformer {
+    blocks: Vec<DecoderBlock>,
+}
+
+impl Transformer {
+    /// Creates a new [`Transformer`] with `num_layers` blocks.
+    pub fn new(num_layers: usize, embed_dim: usize, hidden_dim: usize) -> Self {
+        let mut blocks = Vec::with_capacity(num_layers);
+        for _ in 0..num_layers {
+            blocks.push(DecoderBlock::new(embed_dim, hidden_dim));
+        }
+        Self { blocks }
+    }
+
+    /// Runs the transformer on the provided sequence.
+    pub fn forward(&self, input: &[Vec<f32>]) -> Vec<Vec<f32>> {
+        self.blocks.iter().fold(input.to_owned(), |acc, block| block.forward(&acc))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transformer_forward_shape() {
+        let model = Transformer::new(3, 2, 2);
+        let input = vec![vec![1.0f32, -1.0]];
+        let output = model.forward(&input);
+        assert_eq!(output.len(), input.len());
+        assert_eq!(output[0].len(), input[0].len());
+    }
+}


### PR DESCRIPTION
## Summary
- extend the Rust core with a new `Transformer` module made of stacked decoder blocks
- expose `Transformer` in `lib.rs`
- document new progress in the main README

## Testing
- `cargo test --manifest-path core/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686c2c6d2550832283d72958bfc1a69f