### PR TITLE
Add embedding layer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,4 @@ dRAGon/
 * Created a minimal decoder block chaining attention and feedforward (`core/src/decoder.rs`).
 * Introduced a simple multi-layer `Transformer` composed of decoder blocks (`core/src/transformer.rs`).
 * Added a basic layer normalization module and integrated it into the decoder blocks (`core/src/layernorm.rs`).
+* Implemented a simple token embedding lookup layer (`core/src/embedding.rs`).

--- a/core/src/embedding.rs
+++ b/core/src/embedding.rs
@@ -1,0 +1,42 @@
+/// Simple token embedding layer.
+///
+/// Maps token indices to embedding vectors via a lookup table.
+pub struct Embedding {
+    pub weights: Vec<Vec<f32>>, // shape: vocab_size x embed_dim
+}
+
+impl Embedding {
+    /// Creates a new [`Embedding`] with the provided weight matrix.
+    pub fn new(weights: Vec<Vec<f32>>) -> Self {
+        Self { weights }
+    }
+
+    /// Looks up embeddings for each token id in `input`.
+    pub fn forward(&self, input: &[usize]) -> Vec<Vec<f32>> {
+        input
+            .iter()
+            .map(|&idx| self.weights[idx].clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedding_lookup() {
+        let weights = vec![
+            vec![0.1, 0.2],
+            vec![0.3, 0.4],
+            vec![0.5, 0.6],
+        ];
+        let emb = Embedding::new(weights);
+        let input = vec![2usize, 0, 1];
+        let output = emb.forward(&input);
+        assert_eq!(output.len(), 3);
+        assert_eq!(output[0], vec![0.5, 0.6]);
+        assert_eq!(output[1], vec![0.1, 0.2]);
+        assert_eq!(output[2], vec![0.3, 0.4]);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod embedding;
 pub mod attention;
 pub mod feedforward;
 pub mod decoder;


### PR DESCRIPTION
## Summary
- implement a simple token Embedding layer in Rust core
- expose the module via `lib.rs`
- document embedding layer progress in project README

## Testing
- `cargo test --quiet`
- `cargo fmt -- --check` *(fails: component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c2eef622083228cb17c38dba3a363