### PR TITLE
Add inference CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,4 @@ dRAGon/
   `Model` struct (`core/src/model.rs`) to enable end-to-end inference.
 * Added a naive rotary positional embedding module (`core/src/rotary.rs`) and
   integrated it into the `Model`.
+* Introduced a basic command-line inference tool (`core/src/bin/infer.rs`) demonstrating model usage.

--- a/core/README.md
+++ b/core/README.md
@@ -1,1 +1,10 @@
 # dragon-core\n\nRust transformer core.
+
+## CLI Example
+
+A simple command-line tool `infer` demonstrates how to run the model on a list
+of token ids:
+
+```bash
+cargo run --bin infer -- 0 1 2
+```

--- a/core/src/bin/infer.rs
+++ b/core/src/bin/infer.rs
@@ -1,0 +1,24 @@
+use dragon_core::model::Model;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("Usage: infer <token ids>");
+        std::process::exit(1);
+    }
+
+    let tokens: Vec<usize> = args.iter().map(|a| a.parse::<usize>().expect("invalid token" )).collect();
+
+    // Example model dimensions; in real usage load actual weights.
+    let vocab_size = 16;
+    let embed_dim = 4;
+    let hidden_dim = 4;
+    let num_layers = 1;
+
+    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers);
+    let logits = model.forward(&tokens);
+
+    for (idx, logit) in logits.iter().enumerate() {
+        println!("step {} -> {:?}", idx, logit);
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple command line example `infer`
- document CLI usage in `core/README.md`
- note the new tool in main README

## Testing
- `cargo test --quiet`
- `cargo run --bin infer --quiet -- 0 1 2`

------
https://chatgpt.com/codex/tasks/task_e_686c3321cffc832296e806cbbb58ad05