### PR TITLE
Implement PHP API bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,4 @@ dRAGon/
 * Added a naive rotary positional embedding module (`core/src/rotary.rs`) and
   integrated it into the `Model`.
 * Introduced a basic command-line inference tool (`core/src/bin/infer.rs`) demonstrating model usage.
+* Added a simple PHP endpoint invoking the Rust inference binary (`php/api/index.php`).

--- a/php/api/README.md
+++ b/php/api/README.md
@@ -1,1 +1,16 @@
 # API
+
+Simple HTTP endpoint that invokes the Rust inference binary.
+
+## Usage
+
+1. Build the Rust core: from the repo root run `cargo build --bin infer`.
+2. Start a PHP server inside this directory:
+   ```bash
+   php -S localhost:8080
+   ```
+3. Send a POST request with JSON tokens:
+   ```bash
+   curl -X POST -d '{"tokens": [0,1,2]}' http://localhost:8080/index.php
+   ```
+   The response contains the raw output from the inference binary.

--- a/php/api/index.php
+++ b/php/api/index.php
@@ -1,3 +1,40 @@
 <?php
-// Entry point for dragon PHP API
+// Simple HTTP endpoint to run dragon-core inference.
+// Expects JSON: {"tokens": [1,2,3]}
+
+header('Content-Type: application/json');
+
+$raw = file_get_contents('php://input');
+if ($raw === false) {
+    http_response_code(400);
+    echo json_encode(['error' => 'No input']);
+    exit;
+}
+
+$data = json_decode($raw, true);
+if (!is_array($data) || !isset($data['tokens']) || !is_array($data['tokens'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Expected JSON with "tokens" array']);
+    exit;
+}
+
+$tokens = array_map('intval', $data['tokens']);
+$binary = realpath(__DIR__ . '/../../core/target/debug/infer');
+
+if ($binary === false || !is_file($binary)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Inference binary not found']);
+    exit;
+}
+
+$cmd = escapeshellcmd($binary . ' ' . implode(' ', $tokens));
+$output = shell_exec($cmd);
+
+if ($output === null) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to execute inference binary']);
+    exit;
+}
+
+echo json_encode(['raw' => $output]);
 ?>


### PR DESCRIPTION
## Summary
- create a simple PHP endpoint to invoke the dragon core inference binary
- document how to use the PHP API
- record the new API endpoint in the project README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686c34c473248322b3240f90548f9215