### PR TITLE
Add simple whitespace tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,4 @@ dRAGon/
   integrated it into the `Model`.
 * Introduced a basic command-line inference tool (`core/src/bin/infer.rs`) demonstrating model usage.
 * Added a simple PHP endpoint invoking the Rust inference binary (`php/api/index.php`).
+* Implemented a naive whitespace tokenizer module (`core/src/tokenizer.rs`).

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod transformer;
 pub mod layernorm;
 pub mod rotary;
 pub mod model;
+pub mod tokenizer;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -1,0 +1,64 @@
+/// Naive whitespace tokenizer.
+///
+/// This tokenizer splits text on ASCII whitespace and maps words to
+/// integer ids based on a provided vocabulary. Unknown words are mapped
+/// to a special `unk_id`.
+use std::collections::HashMap;
+
+pub struct WhitespaceTokenizer {
+    vocab: HashMap<String, usize>,
+    inv_vocab: Vec<String>,
+    unk_id: usize,
+}
+
+impl WhitespaceTokenizer {
+    /// Creates a new tokenizer from a list of vocabulary tokens.
+    /// `unk_id` specifies the id returned for unknown words.
+    pub fn new(vocab: Vec<String>, unk_id: usize) -> Self {
+        let mut map = HashMap::new();
+        for (i, tok) in vocab.iter().enumerate() {
+            map.insert(tok.clone(), i);
+        }
+        Self { vocab: map, inv_vocab: vocab, unk_id }
+    }
+
+    /// Encodes space-separated text into token ids.
+    pub fn encode(&self, text: &str) -> Vec<usize> {
+        text.split_whitespace()
+            .map(|w| self.vocab.get(w).cloned().unwrap_or(self.unk_id))
+            .collect()
+    }
+
+    /// Decodes token ids back into a space-separated string.
+    pub fn decode(&self, tokens: &[usize]) -> String {
+        tokens
+            .iter()
+            .map(|&id| self.inv_vocab.get(id).cloned().unwrap_or_else(|| "".into()))
+            .collect::<Vec<String>>()
+            .join(" ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let vocab = vec!["hello".into(), "world".into()];
+        let tok = WhitespaceTokenizer::new(vocab.clone(), 0);
+        let text = "hello world";
+        let ids = tok.encode(text);
+        assert_eq!(ids, vec![0, 1]);
+        let decoded = tok.decode(&ids);
+        assert_eq!(decoded, text);
+    }
+
+    #[test]
+    fn unknown_token() {
+        let vocab = vec!["a".into(), "b".into()];
+        let tok = WhitespaceTokenizer::new(vocab, 1);
+        let ids = tok.encode("c a");
+        assert_eq!(ids, vec![1, 0]);
+    }
+}

--- a/tokenizer/README.md
+++ b/tokenizer/README.md
@@ -1,1 +1,5 @@
 # Tokenizer
+
+This directory stores tokenizer logic and related assets.
+
+A minimal whitespace tokenizer is implemented in `core/src/tokenizer.rs` for early experimentation. It maps space-separated words to integer ids using a provided vocabulary.


### PR DESCRIPTION
## Summary
- add `WhitespaceTokenizer` to handle basic tokenization
- export tokenizer module in library
- document the tokenizer in README and progress notes

## Testing
- `cargo test --manifest-path core/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686c371d0f3c8322b790428748a2ebe1