### PR TITLE
Add text inference CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,4 @@ dRAGon/
 * Introduced a basic command-line inference tool (`core/src/bin/infer.rs`) demonstrating model usage.
 * Added a simple PHP endpoint invoking the Rust inference binary (`php/api/index.php`).
 * Implemented a naive whitespace tokenizer module (`core/src/tokenizer.rs`).
+* Added a CLI to run inference directly on text input (`core/src/bin/infer_text.rs`).

--- a/core/src/bin/infer_text.rs
+++ b/core/src/bin/infer_text.rs
@@ -1,0 +1,55 @@
+use dragon_core::model::Model;
+use dragon_core::tokenizer::WhitespaceTokenizer;
+use std::env;
+use std::fs;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let vocab_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: infer_text <vocab.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+    let text = match args.next() {
+        Some(t) => t,
+        None => {
+            eprintln!("Usage: infer_text <vocab.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+
+    let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
+    let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+
+    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+
+    let tokens = tokenizer.encode(&text);
+
+    let vocab_size = vocab.len();
+    let embed_dim = 4;
+    let hidden_dim = 4;
+    let num_layers = 1;
+
+    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers);
+    let logits = model.forward(&tokens);
+
+    for (idx, logit) in logits.iter().enumerate() {
+        println!("step {} -> {:?}", idx, logit);
+    }
+
+    let predicted: Vec<usize> = logits
+        .iter()
+        .map(|logit| {
+            logit
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                .map(|(i, _)| i)
+                .unwrap_or(0)
+        })
+        .collect();
+    let out_text = tokenizer.decode(&predicted);
+    println!("decoded: {}", out_text);
+}


### PR DESCRIPTION
## Summary
- add a new `infer_text` binary to run the model on text input using the tokenizer
- document the new CLI in `Development Progress`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c3fef554483229c799bc41b16bd11