### PR TITLE
Add text generation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ dRAGon/
 * Added a simple PHP endpoint invoking the Rust inference binary (`php/api/index.php`).
 * Implemented a naive whitespace tokenizer module (`core/src/tokenizer.rs`).
 * Added a CLI to run inference directly on text input (`core/src/bin/infer_text.rs`).
+* Implemented a simple autoregressive text generation CLI (`core/src/bin/generate_text.rs`).

--- a/core/README.md
+++ b/core/README.md
@@ -8,3 +8,9 @@ of token ids:
 ```bash
 cargo run --bin infer -- 0 1 2
 ```
+
+For text-based generation you can use the `generate_text` binary:
+
+```bash
+cargo run --bin generate_text -- tokenizer/vocab.txt "hello" 3
+```

--- a/core/src/bin/generate_text.rs
+++ b/core/src/bin/generate_text.rs
@@ -1,0 +1,46 @@
+use dragon_core::model::Model;
+use dragon_core::tokenizer::WhitespaceTokenizer;
+use std::env;
+use std::fs;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let vocab_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: generate_text <vocab.txt> <prompt> <steps>");
+            std::process::exit(1);
+        }
+    };
+    let prompt = match args.next() {
+        Some(t) => t,
+        None => {
+            eprintln!("Usage: generate_text <vocab.txt> <prompt> <steps>");
+            std::process::exit(1);
+        }
+    };
+    let steps: usize = match args.next() {
+        Some(s) => s.parse().expect("invalid steps"),
+        None => {
+            eprintln!("Usage: generate_text <vocab.txt> <prompt> <steps>");
+            std::process::exit(1);
+        }
+    };
+
+    let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
+    let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+
+    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let mut tokens = tokenizer.encode(&prompt);
+
+    let vocab_size = vocab.len();
+    let embed_dim = 4;
+    let hidden_dim = 4;
+    let num_layers = 1;
+
+    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers);
+    tokens = model.generate(&tokens, steps);
+
+    let out_text = tokenizer.decode(&tokens);
+    println!("{}", out_text);
+}


### PR DESCRIPTION
## Summary
- support greedy text generation
- add `generate_text` CLI example
- document the new CLI in README files

## Testing
- `cargo test --manifest-path core/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686c47544a908322a58084679bfb4ddb