### PR TITLE
Add cross entropy loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,4 @@ dRAGon/
 * Implemented a naive whitespace tokenizer module (`core/src/tokenizer.rs`).
 * Added a CLI to run inference directly on text input (`core/src/bin/infer_text.rs`).
 * Implemented a simple autoregressive text generation CLI (`core/src/bin/generate_text.rs`).
+* Added a cross-entropy loss module for evaluation (`core/src/loss.rs`).

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod layernorm;
 pub mod rotary;
 pub mod model;
 pub mod tokenizer;
+pub mod loss;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/core/src/loss.rs
+++ b/core/src/loss.rs
@@ -1,0 +1,34 @@
+/// Simple cross-entropy loss for logits and integer targets.
+///
+/// The function expects `logits` as a sequence of vectors where each
+/// vector represents unnormalized log probabilities for one step. The
+/// `targets` slice contains the expected token index for each step.
+pub fn cross_entropy(logits: &[Vec<f32>], targets: &[usize]) -> f32 {
+    assert_eq!(logits.len(), targets.len());
+    let mut loss = 0.0f32;
+    for (logit, &target) in logits.iter().zip(targets.iter()) {
+        let max = logit
+            .iter()
+            .cloned()
+            .fold(f32::NEG_INFINITY, f32::max);
+        let exp_sum: f32 = logit.iter().map(|x| (*x - max).exp()).sum();
+        let log_prob = logit[target] - max - exp_sum.ln();
+        loss -= log_prob;
+    }
+    loss / logits.len() as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lower_loss_for_correct_prediction() {
+        let logits_good = vec![vec![2.0f32, 0.1]];
+        let logits_bad = vec![vec![0.1f32, 2.0]];
+        let target = vec![0usize];
+        let good = cross_entropy(&logits_good, &target);
+        let bad = cross_entropy(&logits_bad, &target);
+        assert!(good < bad);
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple cross entropy loss function
- export the loss module
- document new development step

## Testing
- `cargo test --manifest-path core/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686cde2188788322a61c1ea8cf98170e