### PR TITLE
Add text loss CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,4 @@ dRAGon/
 * Added a CLI to run inference directly on text input (`core/src/bin/infer_text.rs`).
 * Implemented a simple autoregressive text generation CLI (`core/src/bin/generate_text.rs`).
 * Added a cross-entropy loss module for evaluation (`core/src/loss.rs`).
+* Added a CLI to compute cross-entropy loss for a text prompt (`core/src/bin/eval_loss.rs`).

--- a/core/src/bin/eval_loss.rs
+++ b/core/src/bin/eval_loss.rs
@@ -1,0 +1,47 @@
+use dragon_core::model::Model;
+use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::loss::cross_entropy;
+use std::env;
+use std::fs;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let vocab_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: eval_loss <vocab.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+    let text = match args.next() {
+        Some(t) => t,
+        None => {
+            eprintln!("Usage: eval_loss <vocab.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+
+    let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
+    let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+
+    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let tokens = tokenizer.encode(&text);
+
+    if tokens.len() < 2 {
+        eprintln!("Need at least two tokens to compute loss");
+        std::process::exit(1);
+    }
+
+    let inputs = &tokens[..tokens.len() - 1];
+    let targets = &tokens[1..];
+
+    let vocab_size = vocab.len();
+    let embed_dim = 4;
+    let hidden_dim = 4;
+    let num_layers = 1;
+
+    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers);
+    let logits = model.forward(inputs);
+    let loss = cross_entropy(&logits, targets);
+    println!("loss: {}", loss);
+}


### PR DESCRIPTION
## Summary
- add `eval_loss` CLI for cross-entropy evaluation
- document new CLI in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686cdf86e6708322bf0d1c989aeb7182