### PR TITLE
Add perplexity evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,4 @@ dRAGon/
 * Implemented a simple autoregressive text generation CLI (`core/src/bin/generate_text.rs`).
 * Added a cross-entropy loss module for evaluation (`core/src/loss.rs`).
 * Added a CLI to compute cross-entropy loss for a text prompt (`core/src/bin/eval_loss.rs`).
+* Added a CLI to compute perplexity for a text prompt (`core/src/bin/eval_perplexity.rs`).

--- a/core/src/bin/eval_perplexity.rs
+++ b/core/src/bin/eval_perplexity.rs
@@ -1,0 +1,47 @@
+use dragon_core::model::Model;
+use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::loss::perplexity;
+use std::env;
+use std::fs;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let vocab_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: eval_perplexity <vocab.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+    let text = match args.next() {
+        Some(t) => t,
+        None => {
+            eprintln!("Usage: eval_perplexity <vocab.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+
+    let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
+    let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+
+    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let tokens = tokenizer.encode(&text);
+
+    if tokens.len() < 2 {
+        eprintln!("Need at least two tokens to compute perplexity");
+        std::process::exit(1);
+    }
+
+    let inputs = &tokens[..tokens.len() - 1];
+    let targets = &tokens[1..];
+
+    let vocab_size = vocab.len();
+    let embed_dim = 4;
+    let hidden_dim = 4;
+    let num_layers = 1;
+
+    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers);
+    let logits = model.forward(inputs);
+    let ppl = perplexity(&logits, targets);
+    println!("perplexity: {}", ppl);
+}

--- a/core/src/loss.rs
+++ b/core/src/loss.rs
@@ -18,6 +18,14 @@ pub fn cross_entropy(logits: &[Vec<f32>], targets: &[usize]) -> f32 {
     loss / logits.len() as f32
 }
 
+/// Computes perplexity from logits and targets using cross-entropy loss.
+///
+/// Perplexity is defined as `exp(cross_entropy)` which corresponds to the
+/// average branching factor the model assigns to the sequence.
+pub fn perplexity(logits: &[Vec<f32>], targets: &[usize]) -> f32 {
+    cross_entropy(logits, targets).exp()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -30,5 +38,15 @@ mod tests {
         let good = cross_entropy(&logits_good, &target);
         let bad = cross_entropy(&logits_bad, &target);
         assert!(good < bad);
+    }
+
+    #[test]
+    fn perplexity_exp_loss() {
+        let logits = vec![vec![1.0f32, 0.0]];
+        let target = vec![0usize];
+        let loss = cross_entropy(&logits, &target);
+        let ppl = perplexity(&logits, &target);
+        let expected = loss.exp();
+        assert!((ppl - expected).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
## Summary
- implement `perplexity` in `core` loss module
- create CLI `eval_perplexity` for evaluating perplexity of a text prompt
- document new CLI in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ce15ab4a88322bc04b60ac167dd24