### PR TITLE
Add example API clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ dRAGon/
 - [ ] Call the Rust core through FFI for zero-copy data flow
 - [ ] Add authentication and rate limiting middleware
 - [ ] Improve logging and structured error handling
-- [ ] Provide example client scripts (PHP and JavaScript)
+- [x] Provide example client scripts (PHP and JavaScript)
 
 ### Training Pipeline
 - [ ] Build a dataset loader for large text corpora

--- a/php/README.md
+++ b/php/README.md
@@ -1,1 +1,16 @@
-# PHP Orchestration\n\nEntry point for dragon API.
+# PHP Orchestration
+
+Entry point for dragon API.
+
+## Example clients
+
+The `examples/` directory contains small scripts that demonstrate how to call
+the API from PHP or Node.js:
+
+```bash
+# Using PHP
+php examples/client.php 0 1 2
+
+# Using Node.js
+node examples/client.js 0 1 2
+```

--- a/php/examples/client.js
+++ b/php/examples/client.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Example Node.js client for the dragon API.
+// Usage: node client.js <token0> <token1> ...
+
+const http = require('http');
+
+const tokens = process.argv.slice(2).map(t => parseInt(t, 10));
+if (tokens.length === 0) {
+  console.error('Usage: node client.js <token0> <token1> ...');
+  process.exit(1);
+}
+
+const data = JSON.stringify({ tokens });
+
+const options = {
+  hostname: 'localhost',
+  port: 8080,
+  path: '/index.php',
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(data)
+  }
+};
+
+const req = http.request(options, res => {
+  res.setEncoding('utf8');
+  let raw = '';
+  res.on('data', chunk => { raw += chunk; });
+  res.on('end', () => { console.log(raw); });
+});
+
+req.on('error', err => {
+  console.error('Request error:', err.message);
+});
+
+req.write(data);
+req.end();
+

--- a/php/examples/client.php
+++ b/php/examples/client.php
@@ -1,0 +1,31 @@
+<?php
+// Example PHP client for the dragon API.
+// Usage: php client.php <token0> <token1> ...
+
+$url = 'http://localhost:8080/index.php';
+$tokens = array_slice($argv, 1);
+if (empty($tokens)) {
+    fwrite(STDERR, "Usage: php client.php <token0> <token1> ...\n");
+    exit(1);
+}
+
+$payload = json_encode(['tokens' => array_map('intval', $tokens)], JSON_UNESCAPED_SLASHES);
+
+$ch = curl_init($url);
+curl_setopt_array($ch, [
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+    CURLOPT_POSTFIELDS => $payload,
+    CURLOPT_RETURNTRANSFER => true,
+]);
+
+$response = curl_exec($ch);
+if ($response === false) {
+    fwrite(STDERR, 'Request failed: ' . curl_error($ch) . "\n");
+    exit(1);
+}
+
+curl_close($ch);
+
+echo $response . PHP_EOL;
+?>


### PR DESCRIPTION
## Summary
- add PHP and Node.js scripts demonstrating how to call the API
- document the example clients in `php/README.md`
- mark the example client script item done in the main README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ce31e266c8322bf2597544cb043e6