### PR TITLE
Add vocabulary training CLI

### DIFF
--- a/core/src/bin/train_vocab.rs
+++ b/core/src/bin/train_vocab.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::io::Write;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let input_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: train_vocab <input.txt> <output.txt> [limit]");
+            std::process::exit(1);
+        }
+    };
+    let output_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: train_vocab <input.txt> <output.txt> [limit]");
+            std::process::exit(1);
+        }
+    };
+    let limit: Option<usize> = args.next().and_then(|s| s.parse().ok());
+
+    let contents = fs::read_to_string(&input_path).expect("failed to read input file");
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for word in contents.split_whitespace() {
+        *counts.entry(word.to_string()).or_insert(0) += 1;
+    }
+
+    let mut items: Vec<(String, usize)> = counts.into_iter().collect();
+    items.sort_by(|a, b| b.1.cmp(&a.1));
+    if let Some(lim) = limit {
+        items.truncate(lim);
+    }
+
+    let mut file = fs::File::create(&output_path).expect("failed to create output file");
+    for (token, _) in items {
+        writeln!(file, "{}", token).expect("failed to write token");
+    }
+}
+

--- a/tokenizer/README.md
+++ b/tokenizer/README.md
@@ -3,3 +3,14 @@
 This directory stores tokenizer logic and related assets.
 
 A minimal whitespace tokenizer is implemented in `core/src/tokenizer.rs` for early experimentation. It maps space-separated words to integer ids using a provided vocabulary.
+
+## Training a vocabulary
+
+A simple helper CLI is available to generate a vocabulary file from a text corpus:
+
+```bash
+cargo run --bin train_vocab <input.txt> <output_vocab.txt> [limit]
+```
+
+`limit` is optional and specifies the maximum number of tokens to keep, sorted by frequency. The resulting vocabulary file contains one token per line and can be used with the CLI tools in `core/src/bin`.
+


### PR DESCRIPTION
## Summary
- add `train_vocab` Rust CLI for building vocab files from text
- document vocabulary training in tokenizer README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ce456fbb88322ad36bc12401f9db8