### PR TITLE
Add quantization utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ dRAGon/
 * Added a cross-entropy loss module for evaluation (`core/src/loss.rs`).
 * Added a CLI to compute cross-entropy loss for a text prompt (`core/src/bin/eval_loss.rs`).
 * Added a CLI to compute perplexity for a text prompt (`core/src/bin/eval_perplexity.rs`).
+* Implemented simple int8 quantization utilities for lightweight inference (`core/src/quant.rs`).
 
 ## \ud83d\udcdd Development To-Do List
 
@@ -175,7 +176,7 @@ dRAGon/
 - [ ] Integrate BLAS-backed matrix multiplication for speed
 - [ ] Expose FFI-friendly API for PHP integration
 - [ ] Support model serialization to `.safetensors`
-- [ ] Implement optional quantization for lightweight inference
+- [x] Implement optional quantization for lightweight inference
 - [ ] Add training loop using `burn` or custom autograd
 
 ### Tokenizer

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod rotary;
 pub mod model;
 pub mod tokenizer;
 pub mod loss;
+pub mod quant;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/core/src/quant.rs
+++ b/core/src/quant.rs
@@ -1,0 +1,93 @@
+pub fn quantize_i8(weights: &[Vec<f32>]) -> (Vec<Vec<i8>>, f32) {
+    let max_abs = weights
+        .iter()
+        .flat_map(|row| row.iter())
+        .fold(0.0f32, |m, &v| m.max(v.abs()));
+    let scale = if max_abs == 0.0 { 1.0 } else { max_abs / 127.0 };
+    let quant = weights
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|&v| ((v / scale).round().clamp(-128.0, 127.0) as i8))
+                .collect::<Vec<i8>>()
+        })
+        .collect::<Vec<_>>();
+    (quant, scale)
+}
+
+pub fn dequantize_i8(weights: &[Vec<i8>], scale: f32) -> Vec<Vec<f32>> {
+    weights
+        .iter()
+        .map(|row| row.iter().map(|&v| v as f32 * scale).collect::<Vec<f32>>())
+        .collect::<Vec<_>>()
+}
+
+pub struct QuantizedLinear {
+    weight: Vec<Vec<i8>>, // shape: in_dim x out_dim
+    bias: Vec<f32>,       // shape: out_dim
+    scale: f32,
+}
+
+impl QuantizedLinear {
+    pub fn new(weight: Vec<Vec<i8>>, bias: Vec<f32>, scale: f32) -> Self {
+        Self { weight, bias, scale }
+    }
+
+    pub fn from_linear(layer: &super::Linear) -> Self {
+        let (wq, s) = quantize_i8(&layer.weight);
+        Self {
+            weight: wq,
+            bias: layer.bias.clone(),
+            scale: s,
+        }
+    }
+
+    pub fn forward(&self, input: &[Vec<f32>]) -> Vec<Vec<f32>> {
+        input
+            .iter()
+            .map(|row| {
+                (0..self.weight[0].len())
+                    .map(|j| {
+                        let mut sum = 0.0f32;
+                        for i in 0..row.len() {
+                            sum += row[i] * self.weight[i][j] as f32 * self.scale;
+                        }
+                        sum + self.bias[j]
+                    })
+                    .collect::<Vec<f32>>()
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Linear;
+
+    #[test]
+    fn quant_dequant_roundtrip() {
+        let weights = vec![vec![0.5f32, -0.5], vec![1.0, -1.0]];
+        let (q, s) = quantize_i8(&weights);
+        let deq = dequantize_i8(&q, s);
+        for i in 0..weights.len() {
+            for j in 0..weights[0].len() {
+                assert!((weights[i][j] - deq[i][j]).abs() < 1e-2);
+            }
+        }
+    }
+
+    #[test]
+    fn quantized_linear_approx() {
+        let weight = vec![vec![0.5f32, -0.5], vec![1.0, -1.0]];
+        let bias = vec![0.1f32, -0.1];
+        let linear = Linear::new(weight.clone(), bias.clone());
+        let qlinear = QuantizedLinear::from_linear(&linear);
+        let input = vec![vec![0.2f32, 0.4]];
+        let out_f = linear.forward(&input);
+        let out_q = qlinear.forward(&input);
+        for j in 0..bias.len() {
+            assert!((out_f[0][j] - out_q[0][j]).abs() < 1e-1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement int8 quantization utilities and `QuantizedLinear`
- export new module from library
- document quantization support in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686ce6601a4483229e95a756f9fc6364