### PR TITLE
Integrate optional BLAS matmul

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A **minimal decoder-only LLM**:
 | ------------------------ | ----------------------------------------- |
 | Tensor Math              | `ndarray`, `tch-rs`, or `burn`            |
 | Tokenizer                | `tokenizers` (Hugging Face Rust bindings) |
-| Matrix Multiplication    | BLAS bindings (`ndarray-linalg`)          |
+| Matrix Multiplication    | BLAS via optional `cblas` FFI            |
 | Attention                | Custom implementation w/ SIMD             |
 | Training Loop (optional) | `burn` or raw autograd                    |
 | File I/O (weights)       | Flatbuffers/serde                         |
@@ -167,12 +167,13 @@ dRAGon/
 * Added a cross-entropy loss module for evaluation (`core/src/loss.rs`).
 * Added a CLI to compute cross-entropy loss for a text prompt (`core/src/bin/eval_loss.rs`).
 * Added a CLI to compute perplexity for a text prompt (`core/src/bin/eval_perplexity.rs`).
+* Added optional BLAS-backed matrix multiplication via FFI (`core/src/blas.rs`).
 
 ## \ud83d\udcdd Development To-Do List
 
 ### Core (Rust)
 - [ ] Replace naive attention with optimized multi-head attention
-- [ ] Integrate BLAS-backed matrix multiplication for speed
+- [x] Integrate BLAS-backed matrix multiplication for speed
 - [ ] Expose FFI-friendly API for PHP integration
 - [ ] Support model serialization to `.safetensors`
 - [ ] Implement optional quantization for lightweight inference

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+libc = "0.2"
+
+[features]
+default = []
+blas = []

--- a/core/src/blas.rs
+++ b/core/src/blas.rs
@@ -1,0 +1,59 @@
+#[cfg(feature = "blas")]
+mod ffi {
+    use libc::c_int;
+    extern "C" {
+        pub fn cblas_sgemm(
+            layout: c_int,
+            transa: c_int,
+            transb: c_int,
+            m: c_int,
+            n: c_int,
+            k: c_int,
+            alpha: f32,
+            a: *const f32,
+            lda: c_int,
+            b: *const f32,
+            ldb: c_int,
+            beta: f32,
+            c: *mut f32,
+            ldc: c_int,
+        );
+    }
+    pub const ROW_MAJOR: c_int = 101;
+    pub const NO_TRANS: c_int = 111;
+}
+
+#[cfg(feature = "blas")]
+pub fn sgemm(m: usize, n: usize, k: usize, a: &[f32], b: &[f32], c: &mut [f32]) {
+    unsafe {
+        ffi::cblas_sgemm(
+            ffi::ROW_MAJOR,
+            ffi::NO_TRANS,
+            ffi::NO_TRANS,
+            m as i32,
+            n as i32,
+            k as i32,
+            1.0,
+            a.as_ptr(),
+            k as i32,
+            b.as_ptr(),
+            n as i32,
+            0.0,
+            c.as_mut_ptr(),
+            n as i32,
+        );
+    }
+}
+
+#[cfg(not(feature = "blas"))]
+pub fn sgemm(m: usize, n: usize, k: usize, a: &[f32], b: &[f32], c: &mut [f32]) {
+    for i in 0..m {
+        for j in 0..n {
+            let mut sum = 0.0f32;
+            for p in 0..k {
+                sum += a[i * k + p] * b[p * n + j];
+            }
+            c[i * n + j] = sum;
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod rotary;
 pub mod model;
 pub mod tokenizer;
 pub mod loss;
+pub mod blas;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
@@ -27,22 +28,30 @@ impl Linear {
 
     /// Applies the linear transformation to an input matrix.
     pub fn forward(&self, input: &[Vec<f32>]) -> Vec<Vec<f32>> {
-        input
-            .iter()
-            .map(|row| {
-                self.weight[0]
-                    .iter()
-                    .enumerate()
-                    .map(|(j, _)| {
-                        row.iter()
-                            .enumerate()
-                            .map(|(i, x)| x * self.weight[i][j])
-                            .sum::<f32>()
-                            + self.bias[j]
-                    })
-                    .collect::<Vec<f32>>()
-            })
-            .collect()
+        let m = input.len();
+        let k = input[0].len();
+        let n = self.weight[0].len();
+
+        let mut a = Vec::with_capacity(m * k);
+        for row in input {
+            a.extend_from_slice(row);
+        }
+
+        let mut b = Vec::with_capacity(k * n);
+        for row in &self.weight {
+            b.extend_from_slice(row);
+        }
+
+        let mut c = vec![0.0f32; m * n];
+        crate::blas::sgemm(m, n, k, &a, &b, &mut c);
+
+        let mut output = vec![vec![0.0f32; n]; m];
+        for i in 0..m {
+            for j in 0..n {
+                output[i][j] = c[i * n + j] + self.bias[j];
+            }
+        }
+        output
     }
 }
 


### PR DESCRIPTION
## Summary
- add FFI bindings for `cblas_sgemm` with fallback implementation
- update `Linear` layer to use BLAS-backed matrix multiplication
- expose new `blas` feature in Cargo
- document BLAS integration in README and mark it done

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686ce625886c8322bdea4c6fea08868e