### PR TITLE
Add safetensors serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ dRAGon/
 - [x] Replace naive attention with optimized multi-head attention
 - [x] Integrate BLAS-backed matrix multiplication for speed
 - [x] Expose FFI-friendly API for PHP integration
-- [ ] Support model serialization to `.safetensors`
+- [x] Support model serialization to `.safetensors`
 - [x] Add training loop using `burn` or custom autograd
 - [x] Implement optional quantization for lightweight inference
 

--- a/core/src/ffi.rs
+++ b/core/src/ffi.rs
@@ -1,4 +1,5 @@
-use std::os::raw::c_ulong;
+use std::os::raw::{c_char, c_ulong};
+use std::ffi::CStr;
 use crate::model::Model;
 
 /// Opaque handle wrapping a `Model` for FFI usage.
@@ -52,4 +53,34 @@ pub extern "C" fn dragon_model_generate(
         }
     }
     result.len() as c_ulong
+}
+
+#[no_mangle]
+pub extern "C" fn dragon_model_save(handle: *mut ModelHandle, path: *const c_char) -> bool {
+    if handle.is_null() || path.is_null() {
+        return false;
+    }
+    let path = unsafe { CStr::from_ptr(path) };
+    let path_str = match path.to_str() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let model = unsafe { &(*handle).model };
+    model.save_safetensors(path_str).is_ok()
+}
+
+#[no_mangle]
+pub extern "C" fn dragon_model_load(path: *const c_char) -> *mut ModelHandle {
+    if path.is_null() {
+        return std::ptr::null_mut();
+    }
+    let path = unsafe { CStr::from_ptr(path) };
+    let path_str = match path.to_str() {
+        Ok(p) => p,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    match Model::load_safetensors(path_str) {
+        Ok(model) => Box::into_raw(Box::new(ModelHandle { model })),
+        Err(_) => std::ptr::null_mut(),
+    }
 }

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -251,4 +251,15 @@ mod tests {
         assert_eq!(generated.len(), 4);
         assert!(generated.iter().all(|&t| t < 2));
     }
+
+    #[test]
+    fn model_save_load_roundtrip() {
+        let model = Model::new(2, 2, 2, 1, 1);
+        let path = "test_model.safetensors";
+        model.save_safetensors(path).unwrap();
+        let loaded = Model::load_safetensors(path).unwrap();
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(model.embedding.weights, loaded.embedding.weights);
+        assert_eq!(model.output_layer.bias, loaded.output_layer.bias);
+    }
 }


### PR DESCRIPTION
## Summary
- expose functions for loading and saving `.safetensors` via FFI
- test that `Model` can roundtrip through `.safetensors`
- mark serialization support as done in README

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686ceaaa37e883228a26547d67a94ff8