### PR TITLE
Fix missing num_heads argument

### DIFF
--- a/core/src/bin/train.rs
+++ b/core/src/bin/train.rs
@@ -43,8 +43,9 @@ fn main() {
     let embed_dim = 4;
     let hidden_dim = 4;
     let num_layers = 1;
+    let num_heads = 1;
 
-    let mut model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers);
+    let mut model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
     let lr = 0.1f32;
 
     for epoch in 0..epochs {

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -173,7 +173,8 @@ impl Model {
             .expect("missing feedforward weight");
         let hidden_dim = ff.shape[1];
 
-        let mut model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers);
+        let num_heads = 1;
+        let mut model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
 
         model.embedding.weights = matrix(embed);
         model.output_layer.weight = matrix(tensors.get("output.weight").unwrap());


### PR DESCRIPTION
## Summary
- add `num_heads` when loading models
- add `num_heads` to training CLI

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686ceac5fe2483229738b01f19a34519