### PR TITLE
Centralize hyperparameters

### DIFF
--- a/core/src/bin/eval_loss.rs
+++ b/core/src/bin/eval_loss.rs
@@ -1,6 +1,7 @@
 use dragon_core::model::Model;
 use dragon_core::tokenizer::WhitespaceTokenizer;
 use dragon_core::loss::cross_entropy;
+use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
 use std::fs;
 
@@ -36,12 +37,7 @@ fn main() {
     let targets = &tokens[1..];
 
     let vocab_size = vocab.len();
-    let embed_dim = 4;
-    let hidden_dim = 4;
-    let num_layers = 1;
-    let num_heads = 1;
-
-    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
+    let model = Model::new(vocab_size, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS);
     let logits = model.forward(inputs);
     let loss = cross_entropy(&logits, targets);
     println!("loss: {}", loss);

--- a/core/src/bin/eval_perplexity.rs
+++ b/core/src/bin/eval_perplexity.rs
@@ -1,6 +1,7 @@
 use dragon_core::model::Model;
 use dragon_core::tokenizer::WhitespaceTokenizer;
 use dragon_core::loss::perplexity;
+use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
 use std::fs;
 
@@ -36,12 +37,7 @@ fn main() {
     let targets = &tokens[1..];
 
     let vocab_size = vocab.len();
-    let embed_dim = 4;
-    let hidden_dim = 4;
-    let num_layers = 1;
-    let num_heads = 1;
-
-    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
+    let model = Model::new(vocab_size, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS);
     let logits = model.forward(inputs);
     let ppl = perplexity(&logits, targets);
     println!("perplexity: {}", ppl);

--- a/core/src/bin/generate_text.rs
+++ b/core/src/bin/generate_text.rs
@@ -1,5 +1,6 @@
 use dragon_core::model::Model;
 use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
 use std::fs;
 
@@ -34,12 +35,7 @@ fn main() {
     let mut tokens = tokenizer.encode(&prompt);
 
     let vocab_size = vocab.len();
-    let embed_dim = 4;
-    let hidden_dim = 4;
-    let num_layers = 1;
-    let num_heads = 1;
-
-    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
+    let model = Model::new(vocab_size, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS);
     tokens = model.generate(&tokens, steps);
 
     let out_text = tokenizer.decode(&tokens);

--- a/core/src/bin/infer.rs
+++ b/core/src/bin/infer.rs
@@ -1,4 +1,5 @@
 use dragon_core::model::Model;
+use dragon_core::hyperparams::{DEFAULT_VOCAB_SIZE, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -10,13 +11,8 @@ fn main() {
     let tokens: Vec<usize> = args.iter().map(|a| a.parse::<usize>().expect("invalid token" )).collect();
 
     // Example model dimensions; in real usage load actual weights.
-    let vocab_size = 16;
-    let embed_dim = 4;
-    let hidden_dim = 4;
-    let num_layers = 1;
-    let num_heads = 1;
-
-    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
+    let vocab_size = DEFAULT_VOCAB_SIZE;
+    let model = Model::new(vocab_size, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS);
     let logits = model.forward(&tokens);
 
     for (idx, logit) in logits.iter().enumerate() {

--- a/core/src/bin/infer_text.rs
+++ b/core/src/bin/infer_text.rs
@@ -1,5 +1,6 @@
 use dragon_core::model::Model;
 use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
 use std::fs;
 
@@ -28,12 +29,7 @@ fn main() {
     let tokens = tokenizer.encode(&text);
 
     let vocab_size = vocab.len();
-    let embed_dim = 4;
-    let hidden_dim = 4;
-    let num_layers = 1;
-    let num_heads = 1;
-
-    let model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
+    let model = Model::new(vocab_size, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS);
     let logits = model.forward(&tokens);
 
     for (idx, logit) in logits.iter().enumerate() {

--- a/core/src/bin/train.rs
+++ b/core/src/bin/train.rs
@@ -1,6 +1,7 @@
 use dragon_core::model::Model;
 use dragon_core::tokenizer::WhitespaceTokenizer;
 use dragon_core::loss::cross_entropy;
+use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS, LEARNING_RATE};
 use std::env;
 use std::fs;
 
@@ -40,13 +41,8 @@ fn main() {
     let targets = &tokens[1..];
 
     let vocab_size = vocab.len();
-    let embed_dim = 4;
-    let hidden_dim = 4;
-    let num_layers = 1;
-    let num_heads = 1;
-
-    let mut model = Model::new(vocab_size, embed_dim, hidden_dim, num_layers, num_heads);
-    let lr = 0.1f32;
+    let mut model = Model::new(vocab_size, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS);
+    let lr = LEARNING_RATE;
 
     for epoch in 0..epochs {
         let embedded = model.embedding.forward(inputs);
@@ -57,7 +53,7 @@ fn main() {
         let loss = cross_entropy(&logits, targets);
         println!("epoch {} loss {}", epoch, loss);
 
-        let mut grad_w = vec![vec![0.0f32; vocab_size]; embed_dim];
+        let mut grad_w = vec![vec![0.0f32; vocab_size]; EMBED_DIM];
         let mut grad_b = vec![0.0f32; vocab_size];
         for (step, &target) in targets.iter().enumerate() {
             let logit = &logits[step];
@@ -67,7 +63,7 @@ fn main() {
             for i in 0..vocab_size {
                 let grad = softmax[i] - if i == target { 1.0 } else { 0.0 };
                 grad_b[i] += grad;
-                for j in 0..embed_dim {
+                for j in 0..EMBED_DIM {
                     grad_w[j][i] += transformed[step][j] * grad;
                 }
             }
@@ -82,7 +78,7 @@ fn main() {
         {
             let weight = model.output_layer.weight_mut();
             for i in 0..vocab_size {
-                for j in 0..embed_dim {
+                for j in 0..EMBED_DIM {
                     weight[j][i] -= lr * grad_w[j][i] / n;
                 }
             }

--- a/core/src/hyperparams.rs
+++ b/core/src/hyperparams.rs
@@ -1,0 +1,8 @@
+/// Default hyperparameters shared across examples and tests.
+pub const DEFAULT_VOCAB_SIZE: usize = 16;
+pub const EMBED_DIM: usize = 4;
+pub const HIDDEN_DIM: usize = 4;
+pub const NUM_LAYERS: usize = 1;
+pub const NUM_HEADS: usize = 1;
+/// Learning rate used by the toy training example.
+pub const LEARNING_RATE: f32 = 0.1;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod blas;
 pub mod serialization;
 pub mod ffi;
 pub mod quant;
+pub mod hyperparams;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/php/examples/ffi_client.php
+++ b/php/examples/ffi_client.php
@@ -16,6 +16,7 @@ $header = "
 ";
 
 $lib = FFI::cdef($header, realpath(__DIR__ . '/../../core/target/debug/libdragon_core.so'));
+require_once __DIR__ . '/../hyperparams.php';
 
 $tokens = array_map('intval', array_slice($argv, 1));
 if (empty($tokens)) {
@@ -23,7 +24,7 @@ if (empty($tokens)) {
     exit(1);
 }
 
-$handle = $lib->dragon_model_create(16, 4, 4, 1);
+$handle = $lib->dragon_model_create(VOCAB_SIZE, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS);
 
 $in = FFI::new("ulong[".count($tokens)."]", false);
 foreach ($tokens as $i => $t) {

--- a/php/hyperparams.php
+++ b/php/hyperparams.php
@@ -1,0 +1,8 @@
+<?php
+// Central hyperparameter definitions mirrored from the Rust code.
+const VOCAB_SIZE = 16;
+const EMBED_DIM = 4;
+const HIDDEN_DIM = 4;
+const NUM_LAYERS = 1;
+const NUM_HEADS = 1;
+const LEARNING_RATE = 0.1;


### PR DESCRIPTION
## Summary
- collect shared hyperparameters in `core/src/hyperparams.rs`
- export the new module from `lib.rs`
- use shared constants in all Rust CLI tools
- expose the same hyperparameters to PHP examples

## Testing
- `cargo check` *(fails: failed to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_686cf30bc4ec8322acfdb03ffd50c9f5