### PR TITLE
Add streaming text dataset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ dRAGon/
 * Added optional BLAS-backed matrix multiplication via FFI (`core/src/blas.rs`).
 * Added a simple training CLI demonstrating custom autograd (`core/src/bin/train.rs`).
 * Implemented simple int8 quantization utilities for lightweight inference (`core/src/quant.rs`).
+* Added a streaming dataset loader for large corpora (`core/src/dataset.rs`).
 
 ## \ud83d\udcdd Development To-Do List
 
@@ -198,7 +199,7 @@ dRAGon/
 - [x] Provide example client scripts (PHP and JavaScript)
 
 ### Training Pipeline
-- [ ] Build a dataset loader for large text corpora
+- [x] Build a dataset loader for large text corpora
 - [ ] Implement shuffling and batching dataloader
 - [ ] Add mixed-precision and gradient accumulation support
 - [ ] Save training checkpoints under `weights/`

--- a/core/src/dataset.rs
+++ b/core/src/dataset.rs
@@ -1,0 +1,76 @@
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+
+use crate::tokenizer::WhitespaceTokenizer;
+
+/// Streaming text dataset backed by a file.
+///
+/// The loader reads the corpus line by line and converts each line
+/// into token id sequences using the provided [`WhitespaceTokenizer`].
+/// This avoids loading the entire dataset into memory and is suitable
+/// for large text corpora.
+pub struct TextDataset {
+    reader: BufReader<File>,
+    tokenizer: WhitespaceTokenizer,
+}
+
+impl TextDataset {
+    /// Opens the dataset at `path` with the given tokenizer.
+    pub fn open<P: AsRef<std::path::Path>>(path: P, tokenizer: WhitespaceTokenizer) -> io::Result<Self> {
+        let file = File::open(path)?;
+        Ok(Self {
+            reader: BufReader::new(file),
+            tokenizer,
+        })
+    }
+
+    /// Returns the next sample as `(input, target)` token id vectors.
+    ///
+    /// `Ok(None)` is returned when the end of the file is reached.
+    pub fn next_sample(&mut self) -> io::Result<Option<(Vec<usize>, Vec<usize>)>> {
+        let mut line = String::new();
+        loop {
+            let bytes = self.reader.read_line(&mut line)?;
+            if bytes == 0 {
+                return Ok(None);
+            }
+            let tokens = self.tokenizer.encode(line.trim_end());
+            line.clear();
+            if tokens.len() > 1 {
+                let input = tokens[..tokens.len() - 1].to_vec();
+                let target = tokens[1..].to_vec();
+                return Ok(Some((input, target)));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn iterate_samples() {
+        let path = std::env::temp_dir().join("dataset_test.txt");
+        {
+            let mut f = File::create(&path).unwrap();
+            writeln!(f, "hello world").unwrap();
+            writeln!(f, "foo bar").unwrap();
+        }
+        let vocab = vec!["hello".into(), "world".into(), "foo".into(), "bar".into()];
+        let tok = WhitespaceTokenizer::new(vocab, 0);
+        let mut ds = TextDataset::open(&path, tok).unwrap();
+
+        let s1 = ds.next_sample().unwrap().unwrap();
+        assert_eq!(s1.0, vec![0]);
+        assert_eq!(s1.1, vec![1]);
+
+        let s2 = ds.next_sample().unwrap().unwrap();
+        assert_eq!(s2.0, vec![2]);
+        assert_eq!(s2.1, vec![3]);
+
+        assert!(ds.next_sample().unwrap().is_none());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod serialization;
 pub mod ffi;
 pub mod quant;
 pub mod hyperparams;
+pub mod dataset;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right


### PR DESCRIPTION
## Summary
- implement `TextDataset` to stream lines from large files using a tokenizer
- expose dataset module in the core crate
- document loader in README and mark task as complete

## Testing
- `cargo test --manifest-path core/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686d3296fb3c83228574287af4644fff