### PR TITLE
Add Swoole server

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ dRAGon/
 - [ ] Document tokenizer usage in `/tokenizer/README.md`
 
 ### PHP API & Integration
-- [ ] Implement async HTTP server with Swoole/ReactPHP
+- [x] Implement async HTTP server with Swoole/ReactPHP
 - [ ] Stream tokens back to clients during generation
 - [ ] Call the Rust core through FFI for zero-copy data flow
 - [ ] Add authentication and rate limiting middleware

--- a/php/api/README.md
+++ b/php/api/README.md
@@ -14,3 +14,14 @@ Simple HTTP endpoint that invokes the Rust inference binary.
    curl -X POST -d '{"tokens": [0,1,2]}' http://localhost:8080/index.php
    ```
    The response contains the raw output from the inference binary.
+
+## Async server (Swoole)
+
+If the [Swoole](https://www.swoole.co.uk/) extension is installed you can run
+an asynchronous server:
+
+```bash
+php swoole_server.php
+```
+
+Requests are identical to the `index.php` example.

--- a/php/api/swoole_server.php
+++ b/php/api/swoole_server.php
@@ -1,0 +1,55 @@
+<?php
+// Asynchronous HTTP server using Swoole to invoke dragon-core inference.
+// Requires the Swoole PHP extension.
+
+use Swoole\Http\Server;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+$host = '0.0.0.0';
+$port = 8080;
+
+$server = new Server($host, $port);
+
+$server->on('start', function (Server $server) use ($host, $port) {
+    echo "Swoole HTTP server listening on http://{$host}:{$port}\n";
+});
+
+$server->on('request', function (Request $request, Response $response) {
+    $response->header('Content-Type', 'application/json');
+
+    if ($request->server['request_method'] !== 'POST') {
+        $response->status(405);
+        $response->end(json_encode(['error' => 'POST only']));
+        return;
+    }
+
+    $data = json_decode($request->rawContent(), true);
+    if (!is_array($data) || !isset($data['tokens']) || !is_array($data['tokens'])) {
+        $response->status(400);
+        $response->end(json_encode(['error' => 'Expected JSON with "tokens" array']));
+        return;
+    }
+
+    $tokens = array_map('intval', $data['tokens']);
+    $binary = realpath(__DIR__ . '/../../core/target/debug/infer');
+
+    if ($binary === false || !is_file($binary)) {
+        $response->status(500);
+        $response->end(json_encode(['error' => 'Inference binary not found']));
+        return;
+    }
+
+    $cmd = escapeshellcmd($binary . ' ' . implode(' ', $tokens));
+    $output = shell_exec($cmd);
+
+    if ($output === null) {
+        $response->status(500);
+        $response->end(json_encode(['error' => 'Failed to execute inference binary']));
+        return;
+    }
+
+    $response->end(json_encode(['raw' => $output]));
+});
+
+$server->start();


### PR DESCRIPTION
## Summary
- add a basic asynchronous HTTP server using Swoole
- document the new server option
- check off async server in the PHP integration task list

## Testing
- `cargo test --manifest-path core/Cargo.toml -- --nocapture` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686d328923888322b60f6e1f1fd471a6