### PR TITLE
Add BPE tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ dRAGon/
   integrated it into the `Model`.
 * Introduced a basic command-line inference tool (`core/src/bin/infer.rs`) demonstrating model usage.
 * Added a simple PHP endpoint invoking the Rust inference binary (`php/api/index.php`).
-* Implemented a naive whitespace tokenizer module (`core/src/tokenizer.rs`).
+* Implemented a minimal byte pair encoding tokenizer (`core/src/tokenizer.rs`).
 * Added a CLI to run inference directly on text input (`core/src/bin/infer_text.rs`).
 * Implemented a simple autoregressive text generation CLI (`core/src/bin/generate_text.rs`).
 * Added a cross-entropy loss module for evaluation (`core/src/loss.rs`).
@@ -182,7 +182,7 @@ dRAGon/
 - [x] Implement optional quantization for lightweight inference
 
 ### Tokenizer
-- [ ] Switch from whitespace tokenizer to SentencePiece/BPE
+- [x] Switch from whitespace tokenizer to SentencePiece/BPE
 - [ ] Provide scripts to train and update vocabularies
 - [ ] Add FFI bindings so PHP can tokenize directly
 - [ ] Include tests for encode/decode round trips

--- a/core/src/bin/eval_loss.rs
+++ b/core/src/bin/eval_loss.rs
@@ -1,5 +1,5 @@
 use dragon_core::model::Model;
-use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::tokenizer::BpeTokenizer;
 use dragon_core::loss::cross_entropy;
 use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
@@ -10,22 +10,39 @@ fn main() {
     let vocab_path = match args.next() {
         Some(p) => p,
         None => {
-            eprintln!("Usage: eval_loss <vocab.txt> <text>");
+            eprintln!("Usage: eval_loss <vocab.txt> <merges.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+    let merges_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: eval_loss <vocab.txt> <merges.txt> <text>");
             std::process::exit(1);
         }
     };
     let text = match args.next() {
         Some(t) => t,
         None => {
-            eprintln!("Usage: eval_loss <vocab.txt> <text>");
+            eprintln!("Usage: eval_loss <vocab.txt> <merges.txt> <text>");
             std::process::exit(1);
         }
     };
 
     let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
     let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+    let merges_contents = fs::read_to_string(merges_path).expect("failed to read merges file");
+    let merges: Vec<(String, String)> = merges_contents
+        .lines()
+        .filter_map(|l| {
+            let mut parts = l.split_whitespace();
+            let a = parts.next()?.to_string();
+            let b = parts.next()?.to_string();
+            Some((a, b))
+        })
+        .collect();
 
-    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let tokenizer = BpeTokenizer::new(vocab.clone(), merges, 0);
     let tokens = tokenizer.encode(&text);
 
     if tokens.len() < 2 {

--- a/core/src/bin/eval_perplexity.rs
+++ b/core/src/bin/eval_perplexity.rs
@@ -1,5 +1,5 @@
 use dragon_core::model::Model;
-use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::tokenizer::BpeTokenizer;
 use dragon_core::loss::perplexity;
 use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
@@ -10,22 +10,39 @@ fn main() {
     let vocab_path = match args.next() {
         Some(p) => p,
         None => {
-            eprintln!("Usage: eval_perplexity <vocab.txt> <text>");
+            eprintln!("Usage: eval_perplexity <vocab.txt> <merges.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+    let merges_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: eval_perplexity <vocab.txt> <merges.txt> <text>");
             std::process::exit(1);
         }
     };
     let text = match args.next() {
         Some(t) => t,
         None => {
-            eprintln!("Usage: eval_perplexity <vocab.txt> <text>");
+            eprintln!("Usage: eval_perplexity <vocab.txt> <merges.txt> <text>");
             std::process::exit(1);
         }
     };
 
     let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
     let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+    let merges_contents = fs::read_to_string(merges_path).expect("failed to read merges file");
+    let merges: Vec<(String, String)> = merges_contents
+        .lines()
+        .filter_map(|l| {
+            let mut parts = l.split_whitespace();
+            let a = parts.next()?.to_string();
+            let b = parts.next()?.to_string();
+            Some((a, b))
+        })
+        .collect();
 
-    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let tokenizer = BpeTokenizer::new(vocab.clone(), merges, 0);
     let tokens = tokenizer.encode(&text);
 
     if tokens.len() < 2 {

--- a/core/src/bin/generate_text.rs
+++ b/core/src/bin/generate_text.rs
@@ -1,5 +1,5 @@
 use dragon_core::model::Model;
-use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::tokenizer::BpeTokenizer;
 use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
 use std::fs;
@@ -9,29 +9,46 @@ fn main() {
     let vocab_path = match args.next() {
         Some(p) => p,
         None => {
-            eprintln!("Usage: generate_text <vocab.txt> <prompt> <steps>");
+            eprintln!("Usage: generate_text <vocab.txt> <merges.txt> <prompt> <steps>");
+            std::process::exit(1);
+        }
+    };
+    let merges_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: generate_text <vocab.txt> <merges.txt> <prompt> <steps>");
             std::process::exit(1);
         }
     };
     let prompt = match args.next() {
         Some(t) => t,
         None => {
-            eprintln!("Usage: generate_text <vocab.txt> <prompt> <steps>");
+            eprintln!("Usage: generate_text <vocab.txt> <merges.txt> <prompt> <steps>");
             std::process::exit(1);
         }
     };
     let steps: usize = match args.next() {
         Some(s) => s.parse().expect("invalid steps"),
         None => {
-            eprintln!("Usage: generate_text <vocab.txt> <prompt> <steps>");
+            eprintln!("Usage: generate_text <vocab.txt> <merges.txt> <prompt> <steps>");
             std::process::exit(1);
         }
     };
 
     let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
     let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+    let merges_contents = fs::read_to_string(merges_path).expect("failed to read merges file");
+    let merges: Vec<(String, String)> = merges_contents
+        .lines()
+        .filter_map(|l| {
+            let mut parts = l.split_whitespace();
+            let a = parts.next()?.to_string();
+            let b = parts.next()?.to_string();
+            Some((a, b))
+        })
+        .collect();
 
-    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let tokenizer = BpeTokenizer::new(vocab.clone(), merges, 0);
     let mut tokens = tokenizer.encode(&prompt);
 
     let vocab_size = vocab.len();

--- a/core/src/bin/infer_text.rs
+++ b/core/src/bin/infer_text.rs
@@ -1,5 +1,5 @@
 use dragon_core::model::Model;
-use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::tokenizer::BpeTokenizer;
 use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
 use std::env;
 use std::fs;
@@ -9,22 +9,39 @@ fn main() {
     let vocab_path = match args.next() {
         Some(p) => p,
         None => {
-            eprintln!("Usage: infer_text <vocab.txt> <text>");
+            eprintln!("Usage: infer_text <vocab.txt> <merges.txt> <text>");
+            std::process::exit(1);
+        }
+    };
+    let merges_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: infer_text <vocab.txt> <merges.txt> <text>");
             std::process::exit(1);
         }
     };
     let text = match args.next() {
         Some(t) => t,
         None => {
-            eprintln!("Usage: infer_text <vocab.txt> <text>");
+            eprintln!("Usage: infer_text <vocab.txt> <merges.txt> <text>");
             std::process::exit(1);
         }
     };
 
     let vocab_contents = fs::read_to_string(vocab_path).expect("failed to read vocab file");
     let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+    let merges_contents = fs::read_to_string(merges_path).expect("failed to read merges file");
+    let merges: Vec<(String, String)> = merges_contents
+        .lines()
+        .filter_map(|l| {
+            let mut parts = l.split_whitespace();
+            let a = parts.next()?.to_string();
+            let b = parts.next()?.to_string();
+            Some((a, b))
+        })
+        .collect();
 
-    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let tokenizer = BpeTokenizer::new(vocab.clone(), merges, 0);
 
     let tokens = tokenizer.encode(&text);
 

--- a/core/src/bin/train.rs
+++ b/core/src/bin/train.rs
@@ -1,5 +1,5 @@
 use dragon_core::model::Model;
-use dragon_core::tokenizer::WhitespaceTokenizer;
+use dragon_core::tokenizer::BpeTokenizer;
 use dragon_core::loss::cross_entropy;
 use dragon_core::hyperparams::{EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS, LEARNING_RATE};
 use std::env;
@@ -10,14 +10,21 @@ fn main() {
     let vocab_path = match args.next() {
         Some(p) => p,
         None => {
-            eprintln!("Usage: train <vocab.txt> <text> [epochs]");
+            eprintln!("Usage: train <vocab.txt> <merges.txt> <text> [epochs]");
+            std::process::exit(1);
+        }
+    };
+    let merges_path = match args.next() {
+        Some(p) => p,
+        None => {
+            eprintln!("Usage: train <vocab.txt> <merges.txt> <text> [epochs]");
             std::process::exit(1);
         }
     };
     let text = match args.next() {
         Some(t) => t,
         None => {
-            eprintln!("Usage: train <vocab.txt> <text> [epochs]");
+            eprintln!("Usage: train <vocab.txt> <merges.txt> <text> [epochs]");
             std::process::exit(1);
         }
     };
@@ -29,8 +36,18 @@ fn main() {
 
     let vocab_contents = fs::read_to_string(&vocab_path).expect("failed to read vocab file");
     let vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+    let merges_contents = fs::read_to_string(&merges_path).expect("failed to read merges file");
+    let merges: Vec<(String, String)> = merges_contents
+        .lines()
+        .filter_map(|l| {
+            let mut parts = l.split_whitespace();
+            let a = parts.next()?.to_string();
+            let b = parts.next()?.to_string();
+            Some((a, b))
+        })
+        .collect();
 
-    let tokenizer = WhitespaceTokenizer::new(vocab.clone(), 0);
+    let tokenizer = BpeTokenizer::new(vocab.clone(), merges, 0);
     let tokens = tokenizer.encode(&text);
     if tokens.len() < 2 {
         eprintln!("Need at least two tokens to train");

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -1,41 +1,92 @@
-/// Naive whitespace tokenizer.
-///
-/// This tokenizer splits text on ASCII whitespace and maps words to
-/// integer ids based on a provided vocabulary. Unknown words are mapped
-/// to a special `unk_id`.
 use std::collections::HashMap;
 
-pub struct WhitespaceTokenizer {
+/// Simple byte pair encoding (BPE) tokenizer.
+///
+/// The tokenizer loads a vocabulary and merge operations and applies
+/// merges greedily based on their rank. It is intentionally minimal and
+/// meant for demonstration only.
+pub struct BpeTokenizer {
     vocab: HashMap<String, usize>,
     inv_vocab: Vec<String>,
+    merges: HashMap<(String, String), usize>,
     unk_id: usize,
 }
 
-impl WhitespaceTokenizer {
-    /// Creates a new tokenizer from a list of vocabulary tokens.
-    /// `unk_id` specifies the id returned for unknown words.
-    pub fn new(vocab: Vec<String>, unk_id: usize) -> Self {
+impl BpeTokenizer {
+    /// Creates a new tokenizer from a list of vocabulary tokens and a list of
+    /// merge pairs ordered by priority. `unk_id` specifies the id returned for
+    /// unknown tokens.
+    pub fn new(
+        vocab: Vec<String>,
+        merges: Vec<(String, String)>,
+        unk_id: usize,
+    ) -> Self {
         let mut map = HashMap::new();
         for (i, tok) in vocab.iter().enumerate() {
             map.insert(tok.clone(), i);
         }
-        Self { vocab: map, inv_vocab: vocab, unk_id }
+        let mut merge_map = HashMap::new();
+        for (rank, (a, b)) in merges.iter().enumerate() {
+            merge_map.insert((a.clone(), b.clone()), rank);
+        }
+        Self {
+            vocab: map,
+            inv_vocab: vocab,
+            merges: merge_map,
+            unk_id,
+        }
     }
 
-    /// Encodes space-separated text into token ids.
-    pub fn encode(&self, text: &str) -> Vec<usize> {
-        text.split_whitespace()
-            .map(|w| self.vocab.get(w).cloned().unwrap_or(self.unk_id))
+    fn encode_word(&self, word: &str) -> Vec<usize> {
+        let mut pieces: Vec<String> = word.chars().map(|c| c.to_string()).collect();
+        if pieces.is_empty() {
+            return Vec::new();
+        }
+        loop {
+            let mut best: Option<(usize, usize)> = None; // (rank, index)
+            for i in 0..pieces.len() - 1 {
+                let pair = (pieces[i].clone(), pieces[i + 1].clone());
+                if let Some(&rank) = self.merges.get(&pair) {
+                    if best.map(|b| rank < b.0).unwrap_or(true) {
+                        best = Some((rank, i));
+                    }
+                }
+            }
+            match best {
+                Some((_rank, idx)) => {
+                    let merged = format!("{}{}", pieces[idx], pieces[idx + 1]);
+                    pieces[idx] = merged;
+                    pieces.remove(idx + 1);
+                    if pieces.len() == 1 {
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+        pieces
+            .into_iter()
+            .map(|p| self.vocab.get(&p).cloned().unwrap_or(self.unk_id))
             .collect()
     }
 
-    /// Decodes token ids back into a space-separated string.
+    /// Encodes text into token ids using greedy BPE merges. Words are split on
+    /// ASCII whitespace before BPE is applied.
+    pub fn encode(&self, text: &str) -> Vec<usize> {
+        let mut ids = Vec::new();
+        for word in text.split_whitespace() {
+            ids.extend(self.encode_word(word));
+        }
+        ids
+    }
+
+    /// Decodes token ids back into text by simply concatenating token strings.
     pub fn decode(&self, tokens: &[usize]) -> String {
         tokens
             .iter()
-            .map(|&id| self.inv_vocab.get(id).cloned().unwrap_or_else(|| "".into()))
+            .map(|&id| self.inv_vocab.get(id).cloned().unwrap_or_default())
             .collect::<Vec<String>>()
-            .join(" ")
+            .join("")
     }
 }
 
@@ -45,20 +96,36 @@ mod tests {
 
     #[test]
     fn encode_decode_roundtrip() {
-        let vocab = vec!["hello".into(), "world".into()];
-        let tok = WhitespaceTokenizer::new(vocab.clone(), 0);
-        let text = "hello world";
+        let vocab = vec![
+            "<unk>".into(),
+            "h".into(),
+            "e".into(),
+            "l".into(),
+            "o".into(),
+            "he".into(),
+            "hel".into(),
+            "hell".into(),
+            "hello".into(),
+        ];
+        let merges = vec![
+            ("h".into(), "e".into()),
+            ("he".into(), "l".into()),
+            ("hel".into(), "l".into()),
+            ("hell".into(), "o".into()),
+        ];
+        let tok = BpeTokenizer::new(vocab.clone(), merges, 0);
+        let text = "hello";
         let ids = tok.encode(text);
-        assert_eq!(ids, vec![0, 1]);
+        assert_eq!(ids, vec![8]);
         let decoded = tok.decode(&ids);
         assert_eq!(decoded, text);
     }
 
     #[test]
     fn unknown_token() {
-        let vocab = vec!["a".into(), "b".into()];
-        let tok = WhitespaceTokenizer::new(vocab, 1);
-        let ids = tok.encode("c a");
-        assert_eq!(ids, vec![1, 0]);
+        let vocab = vec!["<unk>".into(), "h".into()];
+        let tok = BpeTokenizer::new(vocab, Vec::new(), 0);
+        let ids = tok.encode("xy");
+        assert_eq!(ids, vec![0, 0]);
     }
 }

--- a/tokenizer/README.md
+++ b/tokenizer/README.md
@@ -2,7 +2,9 @@
 
 This directory stores tokenizer logic and related assets.
 
-A minimal whitespace tokenizer is implemented in `core/src/tokenizer.rs` for early experimentation. It maps space-separated words to integer ids using a provided vocabulary.
+The project now includes a simple byte pair encoding (BPE) tokenizer implemented in `core/src/tokenizer.rs`. It loads a vocabulary and merge rules from the files in this directory.
+
+Example files `vocab.txt` and `merges.txt` demonstrate the expected format. Each merge line lists two space-separated tokens.
 
 ## Training a vocabulary
 

--- a/tokenizer/merges.txt
+++ b/tokenizer/merges.txt
@@ -1,0 +1,8 @@
+h e
+he l
+hel l
+hell o
+w o
+wo r
+wor l
+worl d

--- a/tokenizer/vocab.txt
+++ b/tokenizer/vocab.txt
@@ -1,0 +1,16 @@
+<unk>
+h
+e
+l
+o
+w
+r
+d
+he
+hel
+hell
+hello
+wo
+wor
+worl
+world


### PR DESCRIPTION
## Summary
- replace whitespace tokenizer with a minimal BPE implementation
- update CLI tools to load vocab and merge files
- document BPE tokenizer usage
- provide example vocab and merge files

## Testing
- `cargo test` *(fails: failed to download crates due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686d326fa31c8322abf1023cb6f1bd0b