### PR TITLE
Add vocabulary utility scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ dRAGon/
 
 ### Tokenizer
 - [x] Switch from whitespace tokenizer to SentencePiece/BPE
-- [ ] Provide scripts to train and update vocabularies
+- [x] Provide scripts to train and update vocabularies
 - [ ] Add FFI bindings so PHP can tokenize directly
 - [ ] Include tests for encode/decode round trips
 - [ ] Support dynamic vocabulary merges during training

--- a/core/src/bin/update_vocab.rs
+++ b/core/src/bin/update_vocab.rs
@@ -1,0 +1,70 @@
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::fs;
+use std::io::Write;
+
+fn usage() {
+    eprintln!("Usage: update_vocab <old_vocab.txt> <new_text.txt> <output_vocab.txt> [limit]");
+}
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let old_vocab_path = match args.next() {
+        Some(p) => p,
+        None => {
+            usage();
+            std::process::exit(1);
+        }
+    };
+    let new_text_path = match args.next() {
+        Some(p) => p,
+        None => {
+            usage();
+            std::process::exit(1);
+        }
+    };
+    let output_path = match args.next() {
+        Some(p) => p,
+        None => {
+            usage();
+            std::process::exit(1);
+        }
+    };
+    let limit: Option<usize> = args.next().and_then(|s| s.parse().ok());
+
+    let vocab_contents = fs::read_to_string(&old_vocab_path).expect("failed to read vocab file");
+    let mut vocab: Vec<String> = vocab_contents.lines().map(|s| s.to_string()).collect();
+    let mut existing: HashSet<String> = vocab.iter().cloned().collect();
+
+    let new_text = fs::read_to_string(&new_text_path).expect("failed to read text file");
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for word in new_text.split_whitespace() {
+        if !existing.contains(word) {
+            *counts.entry(word.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    let mut items: Vec<(String, usize)> = counts.into_iter().collect();
+    items.sort_by(|a, b| b.1.cmp(&a.1));
+
+    for (token, _) in items {
+        if limit.map(|l| vocab.len() < l).unwrap_or(true) {
+            vocab.push(token.clone());
+            existing.insert(token);
+        } else {
+            break;
+        }
+    }
+
+    // if a limit is provided and the vocab exceeds it, truncate
+    if let Some(lim) = limit {
+        if vocab.len() > lim {
+            vocab.truncate(lim);
+        }
+    }
+
+    let mut file = fs::File::create(&output_path).expect("failed to create output file");
+    for token in vocab {
+        writeln!(file, "{}", token).expect("failed to write token");
+    }
+}

--- a/data/tokenizer/README.md
+++ b/data/tokenizer/README.md
@@ -16,3 +16,13 @@ cargo run --bin train_vocab <input.txt> <output_vocab.txt> [limit]
 
 `limit` is optional and specifies the maximum number of tokens to keep, sorted by frequency. The resulting vocabulary file contains one token per line and can be used with the CLI tools in `core/src/bin`.
 
+## Updating a vocabulary
+
+If you already have a vocabulary and want to add tokens from additional text, use the `update_vocab` helper:
+
+```bash
+cargo run --bin update_vocab <old_vocab.txt> <new_text.txt> <output_vocab.txt> [limit]
+```
+
+New tokens are appended to the existing list sorted by frequency. When `limit` is supplied, the final vocabulary will be truncated to at most that many entries.
+


### PR DESCRIPTION
## Summary
- provide a new `update_vocab` CLI to append new tokens to an existing vocabulary
- document how to train and update vocabularies
- mark tokenizer TODO as complete

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo check` *(fails: could not download crates from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686d4fe60e5883228481e26d298aec3d