### PR TITLE
Add PHP tokenization FFI bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ dRAGon/
 ### Tokenizer
 - [x] Switch from whitespace tokenizer to SentencePiece/BPE
 - [ ] Provide scripts to train and update vocabularies
-- [ ] Add FFI bindings so PHP can tokenize directly
+ - [x] Add FFI bindings so PHP can tokenize directly
 - [ ] Include tests for encode/decode round trips
 - [ ] Support dynamic vocabulary merges during training
 - [ ] Document tokenizer usage in `/data/tokenizer/README.md`

--- a/core/src/ffi.rs
+++ b/core/src/ffi.rs
@@ -1,5 +1,6 @@
 use std::os::raw::{c_char, c_ulong};
 use std::ffi::CStr;
+use crate::tokenizer::BpeTokenizer;
 use crate::model::Model;
 
 /// Opaque handle wrapping a `Model` for FFI usage.
@@ -83,4 +84,87 @@ pub extern "C" fn dragon_model_load(path: *const c_char) -> *mut ModelHandle {
         Ok(model) => Box::into_raw(Box::new(ModelHandle { model })),
         Err(_) => std::ptr::null_mut(),
     }
+}
+
+/// Opaque handle wrapping a `BpeTokenizer` for FFI usage.
+#[repr(C)]
+pub struct TokenizerHandle {
+    tok: BpeTokenizer,
+}
+
+#[no_mangle]
+pub extern "C" fn dragon_tokenizer_create(
+    vocab_path: *const c_char,
+    merges_path: *const c_char,
+    unk_id: c_ulong,
+) -> *mut TokenizerHandle {
+    if vocab_path.is_null() || merges_path.is_null() {
+        return std::ptr::null_mut();
+    }
+    let vocab_cstr = unsafe { CStr::from_ptr(vocab_path) };
+    let merges_cstr = unsafe { CStr::from_ptr(merges_path) };
+    let vocab_str = match vocab_cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let merges_str = match merges_cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let vocab_contents = match std::fs::read_to_string(vocab_str) {
+        Ok(c) => c,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let vocab: Vec<String> = vocab_contents.lines().map(|l| l.to_string()).collect();
+    let merges_contents = match std::fs::read_to_string(merges_str) {
+        Ok(c) => c,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let merges: Vec<(String, String)> = merges_contents
+        .lines()
+        .filter_map(|l| {
+            let mut parts = l.split_whitespace();
+            let a = parts.next()?.to_string();
+            let b = parts.next()?.to_string();
+            Some((a, b))
+        })
+        .collect();
+    let tok = BpeTokenizer::new(vocab, merges, unk_id as usize);
+    Box::into_raw(Box::new(TokenizerHandle { tok }))
+}
+
+#[no_mangle]
+pub extern "C" fn dragon_tokenizer_free(handle: *mut TokenizerHandle) {
+    if !handle.is_null() {
+        unsafe {
+            drop(Box::from_raw(handle));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn dragon_tokenizer_encode(
+    handle: *const TokenizerHandle,
+    text: *const c_char,
+    out_ptr: *mut c_ulong,
+    out_cap: c_ulong,
+) -> c_ulong {
+    if handle.is_null() || text.is_null() {
+        return 0;
+    }
+    let tok = unsafe { &(*handle).tok };
+    let text_cstr = unsafe { CStr::from_ptr(text) };
+    let text_str = match text_cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => return 0,
+    };
+    let tokens = tok.encode(text_str);
+    let count = std::cmp::min(tokens.len(), out_cap as usize);
+    unsafe {
+        let out_slice = std::slice::from_raw_parts_mut(out_ptr, count);
+        for (i, &t) in tokens.iter().take(count).enumerate() {
+            out_slice[i] = t as c_ulong;
+        }
+    }
+    count as c_ulong
 }

--- a/php/README.md
+++ b/php/README.md
@@ -14,6 +14,9 @@ php examples/client.php 0 1 2
 # Using Node.js
 node examples/client.js 0 1 2
 
-# Using PHP FFI bindings
+# Using PHP FFI bindings for inference
 php examples/ffi_client.php 0 1 2
+
+# Tokenizing text via FFI
+php examples/ffi_tokenize.php "hello"
 ```

--- a/php/examples/ffi_tokenize.php
+++ b/php/examples/ffi_tokenize.php
@@ -1,0 +1,48 @@
+<?php
+// Example of calling Rust tokenizer via FFI.
+// Usage: php ffi_tokenize.php "your text"
+
+if (!extension_loaded('FFI')) {
+    fwrite(STDERR, "FFI extension not available\n");
+    exit(1);
+}
+
+$header = "
+    typedef unsigned long ulong;
+    typedef struct TokenizerHandle TokenizerHandle;
+    TokenizerHandle* dragon_tokenizer_create(const char* vocab, const char* merges, ulong unk);
+    void dragon_tokenizer_free(TokenizerHandle* handle);
+    ulong dragon_tokenizer_encode(const TokenizerHandle* handle, const char* text, ulong* out, ulong cap);
+";
+
+$lib = FFI::cdef($header, realpath(__DIR__ . '/../../core/target/debug/libdragon_core.so'));
+
+$vocab = realpath(__DIR__ . '/../../data/tokenizer/vocab.txt');
+$merges = realpath(__DIR__ . '/../../data/tokenizer/merges.txt');
+
+if ($vocab === false || $merges === false) {
+    fwrite(STDERR, "Tokenizer files not found\n");
+    exit(1);
+}
+
+$handle = $lib->dragon_tokenizer_create($vocab, $merges, 0);
+
+$input = $argv[1] ?? '';
+if ($input === '') {
+    fwrite(STDERR, "Usage: php ffi_tokenize.php \"text\"\n");
+    exit(1);
+}
+
+$cap = strlen($input) + 16; // enough for demo
+$out = FFI::new("ulong[$cap]", false);
+$len = $lib->dragon_tokenizer_encode($handle, $input, $out, $cap);
+
+$result = [];
+for ($i = 0; $i < $len; $i++) {
+    $result[] = $out[$i];
+}
+
+echo json_encode($result) . PHP_EOL;
+
+$lib->dragon_tokenizer_free($handle);
+?>


### PR DESCRIPTION
## Summary
- expose tokenizer through FFI in `core/src/ffi.rs`
- provide PHP example for tokenizing text via FFI
- document new example in `php/README.md`
- mark README TODO as complete

## Testing
- `cargo check --manifest-path core/Cargo.toml` *(fails: failed to download from `https://index.crates.io/...`)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ff010e883228e15e7e61f3349ff