### PR TITLE
Add SSE streaming endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ dRAGon/
 
 ### PHP API & Integration
 - [x] Implement async HTTP server with Swoole/ReactPHP
-- [ ] Stream tokens back to clients during generation
+- [x] Stream tokens back to clients during generation
 - [ ] Call the Rust core through FFI for zero-copy data flow
 - [ ] Add authentication and rate limiting middleware
 - [ ] Improve logging and structured error handling

--- a/core/src/bin/generate_tokens.rs
+++ b/core/src/bin/generate_tokens.rs
@@ -1,0 +1,39 @@
+use dragon_core::model::Model;
+use dragon_core::hyperparams::{DEFAULT_VOCAB_SIZE, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS};
+use std::io::{self, Write};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let steps: usize = match args.next() {
+        Some(s) => s.parse().expect("invalid steps"),
+        None => {
+            eprintln!("Usage: generate_tokens <steps> <token0> [token1 ...]");
+            std::process::exit(1);
+        }
+    };
+
+    let tokens: Vec<usize> = args.map(|a| a.parse::<usize>().expect("invalid token")).collect();
+    if tokens.is_empty() {
+        eprintln!("Usage: generate_tokens <steps> <token0> [token1 ...]");
+        std::process::exit(1);
+    }
+
+    let mut current = tokens;
+    let vocab_size = DEFAULT_VOCAB_SIZE;
+    let model = Model::new(vocab_size, EMBED_DIM, HIDDEN_DIM, NUM_LAYERS, NUM_HEADS);
+
+    for _ in 0..steps {
+        let logits = model.forward(&current);
+        if let Some(last) = logits.last() {
+            let next = last
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+            current.push(next);
+            println!("{}", next);
+            io::stdout().flush().unwrap();
+        }
+    }
+}

--- a/php/api/README.md
+++ b/php/api/README.md
@@ -25,3 +25,19 @@ php swoole_server.php
 ```
 
 Requests are identical to the `index.php` example.
+
+## Streaming tokens
+
+The `stream.php` endpoint uses **Server-Sent Events** to send tokens as they are
+generated. Start the built-in PHP server and POST a JSON body containing the
+initial tokens and a `steps` value:
+
+```bash
+php -S localhost:8080
+
+curl -N -X POST -H "Content-Type: application/json" \
+     -d '{"tokens": [0,1], "steps": 3}' http://localhost:8080/stream.php
+```
+
+Each token is emitted in an `SSE` data line so clients can display the text as
+soon as it is produced.

--- a/php/api/stream.php
+++ b/php/api/stream.php
@@ -1,0 +1,57 @@
+<?php
+// Streams generated tokens back to the client using Server-Sent Events (SSE).
+// Expects JSON: {"tokens": [1,2,3], "steps": 2}
+
+header('Content-Type: text/event-stream');
+header('Cache-Control: no-cache');
+
+$raw = file_get_contents('php://input');
+if ($raw === false) {
+    http_response_code(400);
+    echo "event: error\ndata: No input\n\n";
+    exit;
+}
+
+$data = json_decode($raw, true);
+if (!is_array($data) || !isset($data['tokens']) || !is_array($data['tokens'])) {
+    http_response_code(400);
+    echo "event: error\ndata: Expected JSON with \"tokens\" array\n\n";
+    exit;
+}
+
+$steps = isset($data['steps']) ? max(1, intval($data['steps'])) : 1;
+$tokens = array_map('intval', $data['tokens']);
+$binary = realpath(__DIR__ . '/../../core/target/debug/generate_tokens');
+
+if ($binary === false || !is_file($binary)) {
+    http_response_code(500);
+    echo "event: error\ndata: Generate binary not found\n\n";
+    exit;
+}
+
+$cmd = escapeshellcmd($binary . ' ' . $steps . ' ' . implode(' ', $tokens));
+$proc = popen($cmd, 'r');
+if ($proc === false) {
+    http_response_code(500);
+    echo "event: error\ndata: Failed to execute binary\n\n";
+    exit;
+}
+
+while (!feof($proc)) {
+    $line = fgets($proc);
+    if ($line === false) {
+        break;
+    }
+    $line = trim($line);
+    if ($line === '') {
+        continue;
+    }
+    echo "data: $line\n\n";
+    ob_flush();
+    flush();
+}
+
+pclose($proc);
+
+echo "event: end\ndata: done\n\n";
+?>

--- a/php/examples/stream_client.php
+++ b/php/examples/stream_client.php
@@ -1,0 +1,31 @@
+<?php
+// Example PHP client for the streaming API.
+// Usage: php stream_client.php <steps> <token0> [token1 ...]
+
+$steps = intval($argv[1] ?? 1);
+$tokens = array_map('intval', array_slice($argv, 2));
+if (empty($tokens)) {
+    fwrite(STDERR, "Usage: php stream_client.php <steps> <token0> [token1 ...]\n");
+    exit(1);
+}
+
+$payload = json_encode(['tokens' => $tokens, 'steps' => $steps], JSON_UNESCAPED_SLASHES);
+
+$ch = curl_init('http://localhost:8080/stream.php');
+curl_setopt_array($ch, [
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+    CURLOPT_POSTFIELDS => $payload,
+    CURLOPT_WRITEFUNCTION => function($ch, $data) {
+        echo $data;
+        return strlen($data);
+    },
+]);
+
+curl_exec($ch);
+if (curl_errno($ch)) {
+    fwrite(STDERR, 'Request failed: ' . curl_error($ch) . "\n");
+}
+
+curl_close($ch);
+?>


### PR DESCRIPTION
## Summary
- add `generate_tokens` Rust binary to emit tokens incrementally
- provide `stream.php` that streams tokens using Server‑Sent Events
- document streaming endpoint and update TODO list
- add example streaming client script

## Testing
- `cargo check` *(fails: failed to download crates.io index)*


------
https://chatgpt.com/codex/tasks/task_e_686d503d50388322a00d55bd5026a01f