### PR TITLE
Add API auth and rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ dRAGon/
 - [x] Implement async HTTP server with Swoole/ReactPHP
 - [ ] Stream tokens back to clients during generation
 - [ ] Call the Rust core through FFI for zero-copy data flow
-- [ ] Add authentication and rate limiting middleware
+- [x] Add authentication and rate limiting middleware
 - [ ] Improve logging and structured error handling
 - [x] Provide example client scripts (PHP and JavaScript)
 

--- a/php/api/README.md
+++ b/php/api/README.md
@@ -15,6 +15,16 @@ Simple HTTP endpoint that invokes the Rust inference binary.
    ```
    The response contains the raw output from the inference binary.
 
+### Authentication
+
+Requests must include an `Authorization: Bearer <token>` header. Set the
+expected token via the `DRAGON_API_KEY` environment variable (default `secret`).
+
+### Rate limiting
+
+Each client IP is limited to 60 requests per minute. Exceeding the limit returns
+HTTP `429`.
+
 ## Async server (Swoole)
 
 If the [Swoole](https://www.swoole.co.uk/) extension is installed you can run

--- a/php/api/index.php
+++ b/php/api/index.php
@@ -2,7 +2,21 @@
 // Simple HTTP endpoint to run dragon-core inference.
 // Expects JSON: {"tokens": [1,2,3]}
 
+require_once __DIR__ . '/middleware.php';
+
 header('Content-Type: application/json');
+
+if (!check_auth_header($_SERVER['HTTP_AUTHORIZATION'] ?? '')) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+if (!update_rate_limit($_SERVER['REMOTE_ADDR'] ?? 'unknown')) {
+    http_response_code(429);
+    echo json_encode(['error' => 'Rate limit exceeded']);
+    exit;
+}
 
 $raw = file_get_contents('php://input');
 if ($raw === false) {

--- a/php/api/middleware.php
+++ b/php/api/middleware.php
@@ -1,0 +1,33 @@
+<?php
+// Simple authentication and rate limiting helpers used by the API.
+
+function check_auth_header(string $header): bool {
+    $expected = getenv('DRAGON_API_KEY') ?: 'secret';
+    if (preg_match('/Bearer\s+(.*)/', $header, $m)) {
+        return hash_equals($expected, trim($m[1]));
+    }
+    return false;
+}
+
+function update_rate_limit(string $ip, int $limit = 60, int $window = 60): bool {
+    $file = sys_get_temp_dir() . '/dragon_rate_' . md5($ip);
+    $now = time();
+    if (is_file($file)) {
+        [$start, $count] = array_map('intval', explode(':', file_get_contents($file) ?: '0:0'));
+        if ($now - $start >= $window) {
+            $start = $now;
+            $count = 1;
+        } else {
+            if ($count >= $limit) {
+                return false;
+            }
+            $count++;
+        }
+    } else {
+        $start = $now;
+        $count = 1;
+    }
+    file_put_contents($file, $start . ':' . $count, LOCK_EX);
+    return true;
+}
+?>

--- a/php/examples/client.js
+++ b/php/examples/client.js
@@ -19,7 +19,8 @@ const options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(data)
+    'Content-Length': Buffer.byteLength(data),
+    'Authorization': 'Bearer ' + (process.env.DRAGON_API_KEY || 'secret')
   }
 };
 

--- a/php/examples/client.php
+++ b/php/examples/client.php
@@ -14,7 +14,10 @@ $payload = json_encode(['tokens' => array_map('intval', $tokens)], JSON_UNESCAPE
 $ch = curl_init($url);
 curl_setopt_array($ch, [
     CURLOPT_POST => true,
-    CURLOPT_HTTPHEADER => ['Content-Type: application/json'],
+    CURLOPT_HTTPHEADER => [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . (getenv('DRAGON_API_KEY') ?: 'secret')
+    ],
     CURLOPT_POSTFIELDS => $payload,
     CURLOPT_RETURNTRANSFER => true,
 ]);


### PR DESCRIPTION
## Summary
- add an auth & rate limiting helper for the API
- enforce middleware in HTTP endpoints
- document auth and rate limit requirements
- update example clients to send `Authorization` header
- mark the README todo item as complete

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `php --version` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d505a8ef4832285ea1f21570d84f6