### PR TITLE
Improve PHP API logging and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ dRAGon/
 - [ ] Stream tokens back to clients during generation
 - [ ] Call the Rust core through FFI for zero-copy data flow
 - [ ] Add authentication and rate limiting middleware
-- [ ] Improve logging and structured error handling
+- [x] Improve logging and structured error handling
 - [x] Provide example client scripts (PHP and JavaScript)
 
 ### Training Pipeline

--- a/php/README.md
+++ b/php/README.md
@@ -2,6 +2,9 @@
 
 Entry point for dragon API.
 
+All API endpoints now emit structured JSON errors and write logs using PHP's
+`error_log` facility.
+
 ## Example clients
 
 The `examples/` directory contains small scripts that demonstrate how to call

--- a/php/api/README.md
+++ b/php/api/README.md
@@ -2,6 +2,9 @@
 
 Simple HTTP endpoint that invokes the Rust inference binary.
 
+Both the synchronous and Swoole servers log to the PHP error log and return
+structured JSON error responses.
+
 ## Usage
 
 1. Build the Rust core: from the repo root run `cargo build --bin infer`.

--- a/php/api/index.php
+++ b/php/api/index.php
@@ -2,39 +2,35 @@
 // Simple HTTP endpoint to run dragon-core inference.
 // Expects JSON: {"tokens": [1,2,3]}
 
-header('Content-Type: application/json');
+require_once __DIR__ . '/util.php';
 
-$raw = file_get_contents('php://input');
-if ($raw === false) {
-    http_response_code(400);
-    echo json_encode(['error' => 'No input']);
-    exit;
+try {
+    $raw = file_get_contents('php://input');
+    if ($raw === false) {
+        respond_error(null, 'No input', 400);
+    }
+
+    $data = json_decode($raw, true);
+    if (!is_array($data) || !isset($data['tokens']) || !is_array($data['tokens'])) {
+        respond_error(null, 'Expected JSON with "tokens" array', 400);
+    }
+
+    $tokens = array_map('intval', $data['tokens']);
+    log_info('Inference request: ' . json_encode($tokens));
+
+    $binary = realpath(__DIR__ . '/../../core/target/debug/infer');
+    if ($binary === false || !is_file($binary)) {
+        respond_error(null, 'Inference binary not found', 500);
+    }
+
+    $cmd = escapeshellcmd($binary . ' ' . implode(' ', $tokens));
+    $output = shell_exec($cmd);
+    if ($output === null) {
+        respond_error(null, 'Failed to execute inference binary', 500);
+    }
+
+    respond_json(null, ['raw' => $output]);
+} catch (Throwable $e) {
+    respond_error(null, 'Unhandled error: ' . $e->getMessage(), 500);
 }
-
-$data = json_decode($raw, true);
-if (!is_array($data) || !isset($data['tokens']) || !is_array($data['tokens'])) {
-    http_response_code(400);
-    echo json_encode(['error' => 'Expected JSON with "tokens" array']);
-    exit;
-}
-
-$tokens = array_map('intval', $data['tokens']);
-$binary = realpath(__DIR__ . '/../../core/target/debug/infer');
-
-if ($binary === false || !is_file($binary)) {
-    http_response_code(500);
-    echo json_encode(['error' => 'Inference binary not found']);
-    exit;
-}
-
-$cmd = escapeshellcmd($binary . ' ' . implode(' ', $tokens));
-$output = shell_exec($cmd);
-
-if ($output === null) {
-    http_response_code(500);
-    echo json_encode(['error' => 'Failed to execute inference binary']);
-    exit;
-}
-
-echo json_encode(['raw' => $output]);
 ?>

--- a/php/api/swoole_server.php
+++ b/php/api/swoole_server.php
@@ -2,6 +2,8 @@
 // Asynchronous HTTP server using Swoole to invoke dragon-core inference.
 // Requires the Swoole PHP extension.
 
+require_once __DIR__ . '/util.php';
+
 use Swoole\Http\Server;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
@@ -16,40 +18,38 @@ $server->on('start', function (Server $server) use ($host, $port) {
 });
 
 $server->on('request', function (Request $request, Response $response) {
-    $response->header('Content-Type', 'application/json');
+    try {
+        if ($request->server['request_method'] !== 'POST') {
+            respond_error($response, 'POST only', 405);
+            return;
+        }
 
-    if ($request->server['request_method'] !== 'POST') {
-        $response->status(405);
-        $response->end(json_encode(['error' => 'POST only']));
-        return;
+        $data = json_decode($request->rawContent(), true);
+        if (!is_array($data) || !isset($data['tokens']) || !is_array($data['tokens'])) {
+            respond_error($response, 'Expected JSON with "tokens" array', 400);
+            return;
+        }
+
+        $tokens = array_map('intval', $data['tokens']);
+        log_info('Inference request: ' . json_encode($tokens));
+
+        $binary = realpath(__DIR__ . '/../../core/target/debug/infer');
+        if ($binary === false || !is_file($binary)) {
+            respond_error($response, 'Inference binary not found', 500);
+            return;
+        }
+
+        $cmd = escapeshellcmd($binary . ' ' . implode(' ', $tokens));
+        $output = shell_exec($cmd);
+        if ($output === null) {
+            respond_error($response, 'Failed to execute inference binary', 500);
+            return;
+        }
+
+        respond_json($response, ['raw' => $output]);
+    } catch (Throwable $e) {
+        respond_error($response, 'Unhandled error: ' . $e->getMessage(), 500);
     }
-
-    $data = json_decode($request->rawContent(), true);
-    if (!is_array($data) || !isset($data['tokens']) || !is_array($data['tokens'])) {
-        $response->status(400);
-        $response->end(json_encode(['error' => 'Expected JSON with "tokens" array']));
-        return;
-    }
-
-    $tokens = array_map('intval', $data['tokens']);
-    $binary = realpath(__DIR__ . '/../../core/target/debug/infer');
-
-    if ($binary === false || !is_file($binary)) {
-        $response->status(500);
-        $response->end(json_encode(['error' => 'Inference binary not found']));
-        return;
-    }
-
-    $cmd = escapeshellcmd($binary . ' ' . implode(' ', $tokens));
-    $output = shell_exec($cmd);
-
-    if ($output === null) {
-        $response->status(500);
-        $response->end(json_encode(['error' => 'Failed to execute inference binary']));
-        return;
-    }
-
-    $response->end(json_encode(['raw' => $output]));
 });
 
 $server->start();

--- a/php/api/util.php
+++ b/php/api/util.php
@@ -1,0 +1,30 @@
+<?php
+function log_message(string $level, string $msg): void {
+    $time = date('c');
+    error_log("[$time][$level] $msg");
+}
+
+function log_info(string $msg): void { log_message('INFO', $msg); }
+function log_error(string $msg): void { log_message('ERROR', $msg); }
+
+function respond_json($resp, array $payload, int $status = 200): void {
+    $body = json_encode($payload, JSON_UNESCAPED_SLASHES);
+    if (is_object($resp) && method_exists($resp, 'header')) {
+        $resp->status($status);
+        $resp->header('Content-Type', 'application/json');
+        $resp->end($body);
+    } else {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo $body;
+    }
+}
+
+function respond_error($resp, string $message, int $status): void {
+    log_error($message);
+    respond_json($resp, ['error' => $message, 'code' => $status], $status);
+    if (!is_object($resp)) {
+        exit;
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add a reusable PHP logger/response helper
- refactor API entry points to use structured error handling and logging
- document logging and error responses
- mark todo for logging as done

## Testing
- `cargo test --quiet` *(fails: could not find `Cargo.toml`)*


------
https://chatgpt.com/codex/tasks/task_e_686d507658688322a2facc5f057d3254