### PR TITLE
Add tokenizer roundtrip test

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ dRAGon/
 - [x] Switch from whitespace tokenizer to SentencePiece/BPE
 - [x] Provide scripts to train and update vocabularies
 - [x] Add FFI bindings so PHP can tokenize directly
-- [ ] Include tests for encode/decode round trips
+- [x] Include tests for encode/decode round trips
 - [ ] Support dynamic vocabulary merges during training
 - [ ] Document tokenizer usage in `/data/tokenizer/README.md`
 

--- a/core/tests/tokenizer_roundtrip.rs
+++ b/core/tests/tokenizer_roundtrip.rs
@@ -1,0 +1,39 @@
+use dragon_core::tokenizer::BpeTokenizer;
+
+#[test]
+fn encode_decode_encode_identity() {
+    let vocab = vec![
+        "<unk>".to_string(),
+        "h".into(),
+        "e".into(),
+        "l".into(),
+        "o".into(),
+        "w".into(),
+        "r".into(),
+        "d".into(),
+        "he".into(),
+        "hel".into(),
+        "hell".into(),
+        "hello".into(),
+        "wo".into(),
+        "wor".into(),
+        "worl".into(),
+        "world".into(),
+    ];
+    let merges = vec![
+        ("h".to_string(), "e".to_string()),
+        ("he".to_string(), "l".to_string()),
+        ("hel".to_string(), "l".to_string()),
+        ("hell".to_string(), "o".to_string()),
+        ("w".to_string(), "o".to_string()),
+        ("wo".to_string(), "r".to_string()),
+        ("wor".to_string(), "l".to_string()),
+        ("worl".to_string(), "d".to_string()),
+    ];
+    let tok = BpeTokenizer::new(vocab, merges, 0);
+    let text = "hello";
+    let ids1 = tok.encode(text);
+    let decoded = tok.decode(&ids1);
+    let ids2 = tok.encode(&decoded);
+    assert_eq!(ids1, ids2);
+}


### PR DESCRIPTION
## Summary
- create a new integration test verifying encode/decode stability of `BpeTokenizer`
- mark README TODO as complete

## Testing
- `cargo test --quiet` *(fails: could not access crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686d66d6583883228700a950b1d5ba7d