### PR TITLE
Update tokenizer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ dRAGon/
 - [x] Support dynamic vocabulary merges during training
 - The `BpeTokenizer` now includes a `learn_merges` helper that adds new
   merge rules from training text on the fly.
-- [ ] Document tokenizer usage in `/data/tokenizer/README.md`
+- [x] Document tokenizer usage in `/data/tokenizer/README.md`
 
 ### PHP API & Integration
 - [x] Implement async HTTP server with Swoole/ReactPHP

--- a/data/tokenizer/README.md
+++ b/data/tokenizer/README.md
@@ -26,3 +26,45 @@ cargo run --bin update_vocab <old_vocab.txt> <new_text.txt> <output_vocab.txt> [
 
 New tokens are appended to the existing list sorted by frequency. When `limit` is supplied, the final vocabulary will be truncated to at most that many entries.
 
+## Using the tokenizer
+
+The BPE tokenizer can be instantiated directly from the vocabulary and merges
+files. Below is a minimal example in Rust:
+
+```rust
+use dragon_core::tokenizer::BpeTokenizer;
+
+let vocab = std::fs::read_to_string("data/tokenizer/vocab.txt")?
+    .lines()
+    .map(|s| s.to_string())
+    .collect();
+let merges = std::fs::read_to_string("data/tokenizer/merges.txt")?
+    .lines()
+    .filter_map(|l| {
+        let mut p = l.split_whitespace();
+        Some((p.next()?.to_string(), p.next()?.to_string()))
+    })
+    .collect();
+let tok = BpeTokenizer::new(vocab, merges, 0);
+
+let ids = tok.encode("hello world");
+let text = tok.decode(&ids);
+```
+
+For a ready-made command-line demonstration you can run:
+
+```bash
+cargo run --bin infer_text data/tokenizer/vocab.txt data/tokenizer/merges.txt "hello world"
+```
+
+### PHP FFI example
+
+The PHP side can call the tokenizer via FFI. The `examples/ffi_tokenize.php`
+script demonstrates this:
+
+```bash
+php php/examples/ffi_tokenize.php "hello world"
+```
+
+It loads `libdragon_core.so` and prints the encoded token ids as JSON.
+


### PR DESCRIPTION
## Summary
- document how to instantiate and call the BPE tokenizer
- show PHP FFI example
- mark todo item as complete in main README

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686d70b3eae883229515b7543e21387a